### PR TITLE
`optional` and `maybe` decoders generate optional Typescript fields

### DIFF
--- a/src/types/guard-tests.ts
+++ b/src/types/guard-tests.ts
@@ -1,6 +1,6 @@
 import { guard, object, string, array } from 'decoders';
 
-// $ExpectType { name: string; tags: string[]; }
+// $ExpectType { name: string; tags: string[]; } & {}
 guard(
     object({
         name: string,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,4 @@
-import { $DecoderType, Decoder, Guard } from './types';
+import { $DecoderType, Decoder, OptionalDecoder, Guard } from './types';
 
 export { guard } from './guard';
 export { compose, map, predicate } from './utils';
@@ -18,4 +18,4 @@ export { maybe, nullable, optional } from './optional';
 export { email, regex, string, url } from './string';
 export { tuple2, tuple3, tuple4, tuple5, tuple6 } from './tuple';
 
-export { $DecoderType, Decoder, Guard };
+export { $DecoderType, Decoder, OptionalDecoder, Guard };

--- a/src/types/object-tests.ts
+++ b/src/types/object-tests.ts
@@ -1,12 +1,12 @@
 import { exact, object, pojo, string } from 'decoders';
 
-// $ExpectType Decoder<{ foo: string; bar: { qux: string; }; }, unknown>
+// $ExpectType Decoder<{ foo: string; bar: { qux: string; } & {}; } & {}, unknown>
 object({
     foo: string,
     bar: object({ qux: string }),
 });
 
-// $ExpectType Decoder<{ foo: string; bar: { qux: string; }; }, unknown>
+// $ExpectType Decoder<{ foo: string; bar: { qux: string; } & {}; } & {}, unknown>
 exact({
     foo: string,
     bar: object({ qux: string }),

--- a/src/types/object.d.ts
+++ b/src/types/object.d.ts
@@ -1,9 +1,11 @@
-import { $DecoderType, Decoder } from './types';
+import { $DecoderType, Decoder, OptionalDecoder, Required, Optional } from './types';
 
 export const pojo: Decoder<{[key: string]: unknown}>;
-export function object<O extends {[key: string]: Decoder<any>}>(mapping: O): Decoder<{
-  [key in keyof O]: $DecoderType<O[key]>
-}>;
-export function exact<O extends {[key: string]: Decoder<any>}>(mapping: O): Decoder<{
-  [key in keyof O]: $DecoderType<O[key]>
-}>;
+export function object<O extends {[key: string]: Decoder<any>}>(mapping: O): Decoder<
+  { [key in keyof Required<O>]: $DecoderType<O[key]> } &
+  { [key in keyof Optional<O>]?: $DecoderType<O[key]> }
+>;
+export function exact<O extends {[key: string]: Decoder<any>}>(mapping: O): Decoder<
+  { [key in keyof Required<O>]: $DecoderType<O[key]> } &
+  { [key in keyof Optional<O>]?: $DecoderType<O[key]> }
+>;

--- a/src/types/optional-tests.ts
+++ b/src/types/optional-tests.ts
@@ -1,10 +1,12 @@
-import { maybe, nullable, optional, string } from 'decoders';
+import { maybe, nullable, object, optional, string } from 'decoders';
 
-optional(string); // $ExpectType Decoder<string | undefined, unknown>
-optional(optional(string)); // $ExpectType Decoder<string | undefined, unknown>
+optional(string); // $ExpectType OptionalDecoder<string, unknown>
+optional(optional(string)); // $ExpectType OptionalDecoder<string, unknown>
 
 nullable(string); // $ExpectType Decoder<string | null, unknown>
 nullable(nullable(string)); // $ExpectType Decoder<string | null, unknown>
 
-maybe(string); // $ExpectType Decoder<string | null | undefined, unknown>
-maybe(maybe(string)); // $ExpectType Decoder<string | null | undefined, unknown>
+maybe(string); // $ExpectType OptionalDecoder<string | null, unknown>
+maybe(maybe(string)); // $ExpectType OptionalDecoder<string | null, unknown>
+
+object({ a: string, b: optional(string) }); // $ExpectType Decoder<{ a: string; } & { b?: string | undefined; }, unknown>

--- a/src/types/optional.d.ts
+++ b/src/types/optional.d.ts
@@ -1,5 +1,5 @@
-import { Decoder } from './types';
+import { Decoder, OptionalDecoder } from './types';
 
-export function optional<T>(decoder: Decoder<T>): Decoder<T | undefined>;
+export function optional<T>(decoder: Decoder<T>): OptionalDecoder<T>;
 export function nullable<T>(decoder: Decoder<T>): Decoder<T | null>;
-export function maybe<T>(decoder: Decoder<T>): Decoder<T | null | undefined>;
+export function maybe<T>(decoder: Decoder<T>): OptionalDecoder<T | null>;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,7 +1,10 @@
 import { Annotation } from 'debrief';
 import Result from 'lemons/Result';
 
-export type $DecoderType<T> = T extends Decoder<infer V> ? V : never;
+export type $DecoderType<T> = (
+  T extends OptionalDecoder<infer V> ? V :
+    (T extends Decoder<infer V> ? V : never)
+);
 
 export interface Guard<T> {
   (blob: unknown): T;
@@ -10,4 +13,24 @@ export type Predicate<T> = (value: T) => boolean;
 export type DecodeResult<T> = Result<Annotation, T>;
 export interface Decoder<T, F = unknown> {
   (blob: F): DecodeResult<T>;
+}
+
+export type FilterVoid<T extends string | number | symbol, O extends any> = {
+  [K in T extends (string | number | symbol)
+  ? (O[T] extends (null | undefined) ? never : T)
+  : never]: O[K]
+};
+
+export type MarkRequired<T, B> = {
+  [K in keyof T]: T[K] extends OptionalDecoder<infer D> ?
+  (B extends false ? T[K] : never) :
+  (B extends true ? T[K] : never)
+};
+
+export type Required<T> = FilterVoid<keyof T, MarkRequired<T, true>>;
+export type Optional<T> = FilterVoid<keyof T, MarkRequired<T, false>>;
+
+export interface OptionalDecoder<T, F = unknown> extends Decoder<T, F> {
+  // This is necessary for Typescript to distinguish between this interface and Decoder
+  R: never;
 }


### PR DESCRIPTION
Fixes #292

This is to make statements like `object({ a: optional(number) })` turn into `{ a?: number }` in Typescript. I borrowed extensively from the similar work done in https://github.com/TCMiranda/joi-extract-type (also MIT licensed). 

I haven't done extensive testing on it but it seems to work well when I play around with it and I added a new test as well. The main caveat is that the object definitions become a little messier.

Instead of
```
{ a: number; b: number | undefined; }
```

You end up with the less readable:
```
{ a: number } & { b? : number | undefined}
```

Or in the case of no optionals:
```
{ a: number; b: number; } & {}
```

And you can see some even more egregious examples in the tests below when you nest objects. IMO that's an OK tradeoff for the increased convenience when writing code. Hope this looks all right to you :)

