### PR TITLE
Tuple1

### DIFF
--- a/src/__tests__/tuple.test.js
+++ b/src/__tests__/tuple.test.js
@@ -2,9 +2,25 @@
 
 import { number } from '../number';
 import { string } from '../string';
-import { tuple2, tuple3, tuple4, tuple5, tuple6 } from '../tuple';
+import { tuple1, tuple2, tuple3, tuple4, tuple5, tuple6 } from '../tuple';
 
 describe('tuples', () => {
+    it('tuple1', () => {
+        const decoder = tuple1(string);
+        expect(decoder(['foo']).unwrap()).toEqual(['foo']);
+        expect(decoder(['foo', 'bar']).isErr()).toBe(true);
+        expect(decoder([42]).isErr()).toBe(true);
+        expect(decoder([42, 13]).isErr()).toBe(true);
+
+        // Invalid
+        expect(decoder('not an array').isErr()).toBe(true);
+        expect(decoder(undefined).isErr()).toBe(true);
+
+        // Wrong arity (not a 1-tuple)
+        expect(decoder([]).isErr()).toBe(true);
+        expect(decoder(['foo', 42, true]).isErr()).toBe(true);
+    });
+
     it('tuple2', () => {
         const decoder = tuple2(string, number);
         expect(decoder(['foo', 42]).unwrap()).toEqual(['foo', 42]);

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,6 @@ export { integer, number, positiveInteger, positiveNumber } from './number';
 export { exact, object, pojo } from './object';
 export { maybe, nullable, optional } from './optional';
 export { email, nonEmptyString, regex, string, url } from './string';
-export { tuple2, tuple3, tuple4, tuple5, tuple6 } from './tuple';
+export { tuple1, tuple2, tuple3, tuple4, tuple5, tuple6 } from './tuple';
 
 export type { $DecoderType, Decoder, Guard };

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -14,8 +14,8 @@ const ntuple = (n: number) =>
     );
 
 /**
- * Builds a Decoder that returns Ok for 2-tuples of [T1, T2], given Decoders
- * for T1 and T2.  Err otherwise.
+ * Builds a Decoder that returns Ok for 1-tuple of [T1], given Decoder
+ * T.  Err otherwise.
  */
 export function tuple1<T>(decoder1: Decoder<T>): Decoder<[T]> {
     return compose(ntuple(1), (blobs: Array<mixed>) => {

--- a/src/tuple.js
+++ b/src/tuple.js
@@ -17,6 +17,25 @@ const ntuple = (n: number) =>
  * Builds a Decoder that returns Ok for 2-tuples of [T1, T2], given Decoders
  * for T1 and T2.  Err otherwise.
  */
+export function tuple1<T>(decoder1: Decoder<T>): Decoder<[T]> {
+    return compose(ntuple(1), (blobs: Array<mixed>) => {
+        const [blob1] = blobs;
+
+        const result1 = decoder1(blob1);
+        try {
+            return Ok([result1.unwrap()]);
+        } catch (e) {
+            // If a decoder error has happened while unwrapping all the
+            // results, try to construct a good error message
+            return Err(annotate([result1.isErr() ? result1.errValue() : result1.value()]));
+        }
+    });
+}
+
+/**
+ * Builds a Decoder that returns Ok for 2-tuples of [T1, T2], given Decoders
+ * for T1 and T2.  Err otherwise.
+ */
 export function tuple2<T1, T2>(decoder1: Decoder<T1>, decoder2: Decoder<T2>): Decoder<[T1, T2]> {
     return compose(ntuple(2), (blobs: Array<mixed>) => {
         const [blob1, blob2] = blobs;


### PR DESCRIPTION
Occasionally one may need to decode a tuple with one entry. `array` may not contain any entries, whereas `tuple2` expects 2. This PR adds a new decoder `tuple1`.