### PR TITLE
Improve inferred types for object() and exact() decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Upcoming
+
+-   **Better type inference** for `object()` and `exact()` decoders (see #515,
+    thanks @dimfeld)
+
 ## v1.21.0
 
 -   **New decoder** [`lazy()`](https://github.com/nvie/decoders#lazy): lazily-evaluated decoder, suitable to define

--- a/src/types/helpers.d.ts
+++ b/src/types/helpers.d.ts
@@ -19,13 +19,9 @@
  *   }
  *
  */
-type Compact<T> = RealCompact<keyof T, T>;
+type Compact<T> = { [K in IsDefined<T, keyof T>]: T[K] };
 
-type RealCompact<K extends keyof T, T> = {
-    [S in IsSet<T, K>]: T[S];
-};
-
-type IsSet<T, K extends keyof T> = K extends any
+type IsDefined<T, K extends keyof T> = K extends any
     ? T[K] extends undefined
         ? never
         : K

--- a/src/types/helpers.d.ts
+++ b/src/types/helpers.d.ts
@@ -1,0 +1,66 @@
+/**
+ * Given a type like:
+ *
+ *   {
+ *     a: string;
+ *     b: number | undefined;
+ *     c: null | undefined;
+ *     d: null;
+ *     e: undefined;
+ *   }
+ *
+ * Will drop all the "undefined" types. In this case, only "e":
+ *
+ *   {
+ *     a: string;
+ *     b: number | undefined;
+ *     c: null | undefined;
+ *     d: null;
+ *   }
+ *
+ */
+type Compact<T> = RealCompact<keyof T, T>;
+
+type RealCompact<K extends keyof T, T> = {
+    [S in IsSet<T, K>]: T[S];
+};
+
+type IsSet<T, K extends keyof T> = K extends any
+    ? T[K] extends undefined
+        ? never
+        : K
+    : never;
+
+export type RequiredKeys<T> = keyof Compact<
+    { [K in keyof T]: undefined extends T[K] ? undefined : 1 }
+>;
+
+export type OptionalKeys<T> = keyof Compact<
+    { [K in keyof T]: undefined extends T[K] ? 1 : undefined }
+>;
+
+/**
+ * Transforms an object type, by marking all fields that contain "undefined"
+ * with a question mark, i.e. allowing implicit-undefineds when
+ * explicit-undefined are also allowed.
+ *
+ * For example, if:
+ *
+ *   type User = {
+ *     name: string;
+ *     age: number | undefined;
+ *   }
+ *
+ * Then AllowImplicit<User> will become equivalent to:
+ *
+ *   {
+ *     name: string;
+ *     age?: number | undefined;
+ *        ^
+ *        Note the question mark
+ *   }
+ */
+type AllowImplicit<T> = { [K in RequiredKeys<T>]-?: T[K] } &
+    { [K in OptionalKeys<T>]+?: T[K] };
+
+export { AllowImplicit };

--- a/src/types/helpers.d.ts
+++ b/src/types/helpers.d.ts
@@ -44,19 +44,19 @@ export type OptionalKeys<T> = keyof Compact<
  *
  *   type User = {
  *     name: string;
- *     age: number | undefined;
+ *     age: number | null | undefined;
  *   }
  *
  * Then AllowImplicit<User> will become equivalent to:
  *
  *   {
  *     name: string;
- *     age?: number | undefined;
+ *     age?: number | null;
  *        ^
  *        Note the question mark
  *   }
  */
 type AllowImplicit<T> = { [K in RequiredKeys<T>]-?: T[K] } &
-    { [K in OptionalKeys<T>]+?: T[K] };
+    { [K in OptionalKeys<T>]+?: Exclude<T[K], undefined> };
 
 export { AllowImplicit };

--- a/src/types/object-tests.ts
+++ b/src/types/object-tests.ts
@@ -1,14 +1,14 @@
-import { exact, object, pojo, string } from 'decoders';
+import { exact, object, optional, pojo, string } from 'decoders';
 
-// $ExpectType Decoder<{ foo: string; bar: { qux: string; }; }, unknown>
+// $ExpectType Decoder<{ bar: { qux: string; }; foo?: string | undefined; }, unknown>
 object({
-    foo: string,
+    foo: optional(string),
     bar: object({ qux: string }),
 });
 
-// $ExpectType Decoder<{ foo: string; bar: { qux: string; }; }, unknown>
+// $ExpectType Decoder<{ bar: { qux: string; }; foo?: string | undefined; }, unknown>
 exact({
-    foo: string,
+    foo: optional(string),
     bar: object({ qux: string }),
 });
 

--- a/src/types/object.d.ts
+++ b/src/types/object.d.ts
@@ -1,17 +1,25 @@
 import { $DecoderType, Decoder } from './types';
+import { AllowImplicit } from './helpers';
+
+export type ObjectDecoderType<T> = AllowImplicit<
+    { [key in keyof T]: $DecoderType<T[key]> }
+>;
 
 export const pojo: Decoder<{ [key: string]: unknown }>;
+
 export function object<O extends { [key: string]: Decoder<any> }>(
     mapping: O
-): Decoder<
-    {
-        [key in keyof O]: $DecoderType<O[key]>;
-    }
->;
+): Decoder<{ [K in keyof ObjectDecoderType<O>]: ObjectDecoderType<O>[K] }>;
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//         This is basically just equivalent to:
+//             ObjectDecoderType<O>
+//
+//         But by "resolving" this with a mapped type, we remove the helper
+//         type names from the inferred type here, making this much easier to
+//         work with while developing.
+
 export function exact<O extends { [key: string]: Decoder<any> }>(
     mapping: O
-): Decoder<
-    {
-        [key in keyof O]: $DecoderType<O[key]>;
-    }
->;
+): Decoder<{ [K in keyof ObjectDecoderType<O>]: ObjectDecoderType<O>[K] }>;
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//         Ditto (see above)


### PR DESCRIPTION
Fixes #292 and #439, and is an alternative implementation of #376 — the trick behind this implementation is basically the same as the one @dimfeld used here, but cleaned up a bit, so we don't get these messy inferred types.

Before this change, the following code would cause an unintuitive TypeScript error:

```typescript
export const verify = guard(
  object({
    name: string,
    age: optional(number),
  })
);
export type User = ReturnType<typeof verify>;

const user: User = { name: '123' };
//    ~~~~
//    Property 'age' is missing in type '{ name: string; }'
// but required in type '{ name: string; age: number | undefined; }'.
```

But after this patch, no more!  In your IDE, you can see the inferred type is both beautiful and pragmatic now — without the need for extra manual annotations:

<img width="694" alt="Screen Shot 2020-06-19 at 17 15 27@2x" src="https://user-images.githubusercontent.com/83844/85175701-54fe6800-b278-11ea-9cd8-f160533c43f6.png">

