### PR TITLE
Add JSON decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v1.23.0
+
+-   **New decoders:**
+
+    -   [`json`](https://github.com/nvie/decoders#json): decodes any valid JSON value
+
+    -   [`jsonObject`](https://github.com/nvie/decoders#jsonObject): decodes any valid
+        JSON object
+
+    -   [`jsonArray`](https://github.com/nvie/decoders#jsonArray): decodes any valid JSON
+        array
+
 ## v1.22.2
 
 -   **New decoders:**

--- a/README.md
+++ b/README.md
@@ -599,6 +599,73 @@ Would equal:
 
 ---
 
+<a name="json" href="#json">#</a> <b>json</b>: <i>Decoder&lt;JSONValue&gt;</i>
+[&lt;&gt;](https://github.com/nvie/decoders/blob/master/src/json.js 'Source')
+
+Returns a decoder capable of decoding **any valid JSON value**:
+
+-   `null`
+-   `string`
+-   `number`
+-   `boolean`
+-   `{ [string]: JSONValue }`
+-   `Array<JSONValue>`
+
+```javascript
+const mydecoder = guard(json);
+mydecoder({
+    name: 'Amir',
+    age: 27,
+    admin: true,
+    image: null,
+    tags: ['vip', 'staff'],
+});
+```
+
+Any value returned by `JSON.parse()` should decode without failure.
+
+---
+
+<a name="jsonObject" href="#jsonObject">#</a> <b>jsonObject</b>:
+<i>Decoder&lt;JSONObject&gt;</i>
+[&lt;&gt;](https://github.com/nvie/decoders/blob/master/src/json.js 'Source')
+
+Like `json`, but will only decode when the JSON value is an object.
+
+```javascript
+const mydecoder = guard(json);
+mydecoder({}); // OK
+mydecoder({ name: 'Amir' }); // OK
+
+// Error: the following values are valid JSON values, but not Objects
+mydecoder([]); // Error
+mydecoder([{ name: 'Alice' }, { name: 'Bob' }]); // Error
+mydecoder('hello'); // Error
+mydecoder(null); // Error
+```
+
+---
+
+<a name="jsonArray" href="#jsonArray">#</a> <b>jsonArray</b>:
+<i>Decoder&lt;JSONArray&gt;</i>
+[&lt;&gt;](https://github.com/nvie/decoders/blob/master/src/json.js 'Source')
+
+Like `json`, but will only decode when the JSON value is an array.
+
+```javascript
+const mydecoder = guard(json);
+mydecoder([]); // OK
+mydecoder([{ name: 'Amir' }]); // OK
+
+// Error: the following values are valid JSON values, but not Objects
+mydecoder({}); // Error
+mydecoder({ name: 'Alice' }); // Error
+mydecoder('hello'); // Error
+mydecoder(null); // Error
+```
+
+---
+
 <a name="either" href="#either">#</a> <b>either</b><i>&lt;T1,
 T2&gt;</i>(<i>Decoder&lt;T1&gt;</i>, <i>Decoder&lt;T2&gt;</i>): <i>Decoder&lt;T1 |
 T2&gt;</i><br />

--- a/src/__tests__/json.test.js
+++ b/src/__tests__/json.test.js
@@ -1,0 +1,127 @@
+// @flow strict
+
+import { jsonArray, jsonObject, json } from '../json';
+import { guard } from '../guard';
+
+describe('decoder', () => {
+    const decoder = json;
+
+    it('decodes null', () => {
+        expect(guard(decoder)(null)).toEqual(null);
+    });
+
+    it('decodes strings', () => {
+        expect(guard(decoder)('')).toEqual('');
+        expect(guard(decoder)('hello')).toEqual('hello');
+    });
+
+    it('decodes numbers', () => {
+        expect(guard(decoder)(0)).toEqual(0);
+        expect(guard(decoder)(0.0)).toEqual(0.0);
+        expect(guard(decoder)(3.141529)).toEqual(3.141529);
+        expect(guard(decoder)(-3.141529)).toEqual(-3.141529);
+    });
+
+    it('decodes booleans', () => {
+        expect(guard(decoder)(true)).toEqual(true);
+        expect(guard(decoder)(false)).toEqual(false);
+    });
+
+    it('decodes JSON arrays', () => {
+        expect(guard(decoder)([])).toEqual([]);
+        expect(guard(decoder)([1, true, 'hi'])).toEqual([1, true, 'hi']);
+        expect(guard(decoder)([[1], [[true, 'hi']]])).toEqual([[1], [[true, 'hi']]]);
+        expect(guard(decoder)([[1], [{ a: true, b: 'hi' }]])).toEqual([
+            [1],
+            [{ a: true, b: 'hi' }],
+        ]);
+    });
+
+    it('decodes JSON objects', () => {
+        expect(guard(decoder)({})).toEqual({});
+        expect(guard(decoder)({ a: 1, b: true, c: 'hi' })).toEqual({
+            a: 1,
+            b: true,
+            c: 'hi',
+        });
+        expect(guard(decoder)({ a: { a: { a: [1] } } })).toEqual({
+            a: { a: { a: [1] } },
+        });
+    });
+
+    it('invalid', () => {
+        expect(() => guard(decoder)(undefined)).toThrow();
+        expect(() => guard(decoder)(NaN)).toThrow();
+        expect(() => guard(decoder)(new Date())).toThrow();
+        expect(() => guard(decoder)([new Date()])).toThrow();
+        expect(() => guard(decoder)({ a: new Date() })).toThrow();
+    });
+});
+
+describe('jsonObject', () => {
+    const decoder = jsonObject;
+
+    it('decodes JSON objects', () => {
+        expect(guard(decoder)({})).toEqual({});
+        expect(guard(decoder)({ a: 1, b: true, c: 'hi' })).toEqual({
+            a: 1,
+            b: true,
+            c: 'hi',
+        });
+        expect(guard(decoder)({ a: { a: { a: [1] } } })).toEqual({
+            a: { a: { a: [1] } },
+        });
+    });
+
+    it('invalid', () => {
+        expect(() => guard(decoder)(null)).toThrow();
+        expect(() => guard(decoder)('')).toThrow();
+        expect(() => guard(decoder)('hi')).toThrow();
+        expect(() => guard(decoder)(0)).toThrow();
+        expect(() => guard(decoder)(-3.1415)).toThrow();
+        expect(() => guard(decoder)(42)).toThrow();
+        expect(() => guard(decoder)(true)).toThrow();
+        expect(() => guard(decoder)(false)).toThrow();
+        expect(() => guard(decoder)(undefined)).toThrow();
+        expect(() => guard(decoder)(NaN)).toThrow();
+        expect(() => guard(decoder)([])).toThrow();
+        expect(() => guard(decoder)([1])).toThrow();
+        expect(() => guard(decoder)(['hi'])).toThrow();
+        expect(() => guard(decoder)(new Date())).toThrow();
+        expect(() => guard(decoder)([new Date()])).toThrow();
+        expect(() => guard(decoder)({ a: new Date() })).toThrow();
+    });
+});
+
+describe('jsonArray', () => {
+    const decoder = jsonArray;
+
+    it('decodes JSON arrays', () => {
+        expect(guard(decoder)([])).toEqual([]);
+        expect(guard(decoder)([1, true, 'hi'])).toEqual([1, true, 'hi']);
+        expect(guard(decoder)([[1], [[true, 'hi']]])).toEqual([[1], [[true, 'hi']]]);
+        expect(guard(decoder)([[1], [{ a: true, b: 'hi' }]])).toEqual([
+            [1],
+            [{ a: true, b: 'hi' }],
+        ]);
+    });
+
+    it('invalid', () => {
+        expect(() => guard(decoder)(null)).toThrow();
+        expect(() => guard(decoder)('')).toThrow();
+        expect(() => guard(decoder)('hi')).toThrow();
+        expect(() => guard(decoder)(0)).toThrow();
+        expect(() => guard(decoder)(-3.1415)).toThrow();
+        expect(() => guard(decoder)(42)).toThrow();
+        expect(() => guard(decoder)(true)).toThrow();
+        expect(() => guard(decoder)(false)).toThrow();
+        expect(() => guard(decoder)(undefined)).toThrow();
+        expect(() => guard(decoder)(NaN)).toThrow();
+        expect(() => guard(decoder)({})).toThrow();
+        expect(() => guard(decoder)({ a: 1, b: true, c: 'hi' })).toThrow();
+        expect(() => guard(decoder)({ a: { a: { a: [1] } } })).toThrow();
+        expect(() => guard(decoder)(new Date())).toThrow();
+        expect(() => guard(decoder)([new Date()])).toThrow();
+        expect(() => guard(decoder)({ a: new Date() })).toThrow();
+    });
+});

--- a/src/__tests__/json.test.js
+++ b/src/__tests__/json.test.js
@@ -1,7 +1,7 @@
 // @flow strict
 
-import { jsonArray, jsonObject, json } from '../json';
 import { guard } from '../guard';
+import { json, jsonArray, jsonObject } from '../json';
 
 describe('decoder', () => {
     const decoder = json;

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ export {
 } from './either';
 export { fail } from './fail';
 export { instanceOf } from './instanceOf';
+export { json, jsonObject, jsonArray } from './json';
 export { lazy } from './lazy';
 export { mapping, dict } from './mapping';
 export { integer, number, positiveInteger, positiveNumber } from './number';
@@ -51,3 +52,4 @@ export { tuple1, tuple2, tuple3, tuple4, tuple5, tuple6 } from './tuple';
 
 export type { Decoder, Guard };
 export type { $DecoderType, $GuardType };
+export type { JSONValue, JSONObject, JSONArray } from './json';

--- a/src/json.js
+++ b/src/json.js
@@ -1,0 +1,28 @@
+// @flow strict
+
+import { array } from './array';
+import { boolean } from './boolean';
+import { dict } from './mapping';
+import { either6 } from './either';
+import { lazy } from './lazy';
+import { null_ } from './constants';
+import { number } from './number';
+import { string } from './string';
+import type { Decoder } from './types';
+
+export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
+export type JSONObject = { [string]: JSONValue };
+export type JSONArray = Array<JSONValue>;
+
+export const jsonObject: Decoder<JSONObject> = lazy(() => dict(json));
+
+export const jsonArray: Decoder<JSONArray> = lazy(() => array(json));
+
+export const json: Decoder<JSONValue> = either6(
+    null_,
+    string,
+    number,
+    boolean,
+    jsonObject,
+    jsonArray
+);

--- a/src/json.js
+++ b/src/json.js
@@ -2,10 +2,10 @@
 
 import { array } from './array';
 import { boolean } from './boolean';
-import { dict } from './mapping';
+import { null_ } from './constants';
 import { either6 } from './either';
 import { lazy } from './lazy';
-import { null_ } from './constants';
+import { dict } from './mapping';
 import { number } from './number';
 import { string } from './string';
 import type { Decoder } from './types';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -21,6 +21,7 @@ export {
 } from './either';
 export { fail } from './fail';
 export { instanceOf } from './instanceOf';
+export { json, jsonArray, jsonObject } from './json';
 export { lazy } from './lazy';
 export { mapping, dict } from './mapping';
 export { integer, number, positiveInteger, positiveNumber } from './number';
@@ -31,5 +32,6 @@ export { tuple2, tuple3, tuple4, tuple5, tuple6 } from './tuple';
 
 export { Decoder, Guard };
 export { DecoderType, GuardType };
+export { JSONArray, JSONObject, JSONValue } from './json';
 
 export type $DecoderType<T> = DecoderType<T>; // Alias for backward compatibility

--- a/src/types/json-tests.ts
+++ b/src/types/json-tests.ts
@@ -1,0 +1,10 @@
+import { json, jsonObject, jsonArray } from 'decoders';
+
+// $ExpectType JSONValue
+json('hi').unwrap();
+
+// $ExpectType JSONObject
+jsonObject({}).unwrap();
+
+// $ExpectType JSONArray
+jsonArray([]).unwrap();

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -1,0 +1,9 @@
+import { Decoder } from './types';
+
+export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
+export type JSONObject = { [key: string]: JSONValue };
+export type JSONArray = Array<JSONValue>;
+
+export function json: Decoder<JSONValue>;
+export function jsonArray: Decoder<JSONArray>;
+export function jsonObject: Decoder<JSONObject>;

--- a/src/types/json.d.ts
+++ b/src/types/json.d.ts
@@ -1,9 +1,11 @@
 import { Decoder } from './types';
 
 export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
-export type JSONObject = { [key: string]: JSONValue };
-export type JSONArray = Array<JSONValue>;
+export interface JSONObject {
+    [key: string]: JSONValue;
+}
+export type JSONArray = JSONValue[];
 
-export function json: Decoder<JSONValue>;
-export function jsonArray: Decoder<JSONArray>;
-export function jsonObject: Decoder<JSONObject>;
+export const json: Decoder<JSONValue>;
+export const jsonArray: Decoder<JSONArray>;
+export const jsonObject: Decoder<JSONObject>;


### PR DESCRIPTION
This adds the following new decoders:

- `json` will decode any valid JSON value (aka any value returned by `JSON.parse()`)
- `jsonArray` – similar, but will only accept values that are arrays
- `jsonObject` – similar, but will only accept values that are objects
