### PR TITLE
added export for nonEmptyArray function to array.d.ts 

### DIFF
--- a/src/types/array.d.ts
+++ b/src/types/array.d.ts
@@ -2,3 +2,5 @@ import { Decoder } from './types';
 
 export const poja: Decoder<unknown[]>;
 export function array<T>(decoder: Decoder<T>): Decoder<T[]>;
+export function nonEmptyArray<T>(decoder: Decoder<T>): Decoder<T[]>;
+


### PR DESCRIPTION
nonEmptyArray function is defined in array.js but is not exported from the type definition.