### PR TITLE
Implicit missing keys in object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.23.3-pre1
+
+-   The returned values from `object()`, `inexact()`, and `exact()` decoders
+    will now return implicit-`undefined` rather than explicit-`undefined` for
+    fields that are optional (#574, thanks @w01fgang!)
+
 ## v1.23.2
 
 -   Add missing exports for `nonEmptyArray` and `nonEmptyString` (for TypeScript)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## v1.23.3-pre1
+## v1.23.3
 
--   The returned values from `object()`, `inexact()`, and `exact()` decoders
-    will now return implicit-`undefined` rather than explicit-`undefined` for
-    fields that are optional (#574, thanks @w01fgang!)
+-   Returned objects that are the result from `object()`, `inexact()`, and
+    `exact()` decoders will no longer contain explicit `undefined` values for
+    optional keys, but instead those keys will be missing in the returned
+    object entirely. (#574, thanks @w01fgang!)
 
 ## v1.23.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "decoders",
-    "version": "1.23.2",
+    "version": "1.23.3",
     "description": "Elegant and battle-tested validation library for type-safe input data (for TypeScript and Flow)",
     "license": "MIT",
     "repository": {

--- a/src/__tests__/object.test.js
+++ b/src/__tests__/object.test.js
@@ -36,12 +36,32 @@ describe('objects', () => {
         expect(decoder({ id: 1, name: 'test' }).unwrap()).toEqual({
             id: 1,
             name: 'test',
-            extra: undefined,
         });
         expect(decoder({ id: 1, name: 'test', extra: 'foo' }).unwrap()).toEqual({
             id: 1,
             name: 'test',
             extra: 'foo',
+        });
+    });
+
+    it('objects with optional fields will be implicit-undefined', () => {
+        const defaults = {
+            extra: 'default',
+        };
+
+        const decoder = object({
+            id: number,
+            name: string,
+            extra: optional(string),
+        });
+
+        expect({
+            ...defaults,
+            ...decoder({ id: 1, name: 'test' }).unwrap(),
+        }).toEqual({
+            id: 1,
+            name: 'test',
+            extra: 'default',
         });
     });
 
@@ -154,6 +174,27 @@ describe('exact objects', () => {
         expect(decoder({ foo: [1, 2, 3] }).isErr()).toBe(true); // Missing key "id"
         expect(decoder({ id: 3 }).isErr()).toBe(true); // Invalid field value for "id"
     });
+
+    it('exact objects with optional fields will be implicit-undefined', () => {
+        const defaults = {
+            extra: 'default',
+        };
+
+        const decoder = exact({
+            id: number,
+            name: string,
+            extra: optional(string),
+        });
+
+        expect({
+            ...defaults,
+            ...decoder({ id: 1, name: 'test' }).unwrap(),
+        }).toEqual({
+            id: 1,
+            name: 'test',
+            extra: 'default',
+        });
+    });
 });
 
 describe('inexact objects', () => {
@@ -210,6 +251,31 @@ describe('inexact objects', () => {
         expect(decoder(NaN).isErr()).toBe(true);
         expect(decoder({ foo: [1, 2, 3] }).isErr()).toBe(true); // Missing key "id"
         expect(decoder({ id: 3 }).isErr()).toBe(true); // Invalid field value for "id"
+    });
+
+    it('inexact objects with optional fields will be implicit-undefined', () => {
+        const defaults = {
+            extra: 'default',
+        };
+
+        const decoder = inexact({
+            id: number,
+            name: string,
+            extra: optional(string),
+        });
+
+        expect(
+            // $FlowFixMe[cannot-spread-indexer]
+            {
+                ...defaults,
+                ...decoder({ id: 1, name: 'test', more: 42 }).unwrap(),
+            }
+        ).toEqual({
+            id: 1,
+            name: 'test',
+            extra: 'default',
+            more: 42,
+        });
     });
 });
 

--- a/src/__tests__/object.test.js
+++ b/src/__tests__/object.test.js
@@ -255,26 +255,26 @@ describe('inexact objects', () => {
 
     it('inexact objects with optional fields will be implicit-undefined', () => {
         const defaults = {
-            extra: 'default',
+            foo: 'default',
+            bar: 'default',
         };
 
         const decoder = inexact({
-            id: number,
-            name: string,
-            extra: optional(string),
+            foo: optional(string),
         });
 
         expect(
             // $FlowFixMe[cannot-spread-indexer]
             {
                 ...defaults,
-                ...decoder({ id: 1, name: 'test', more: 42 }).unwrap(),
+                ...decoder({
+                    foo: undefined,
+                    bar: undefined,
+                }).unwrap(),
             }
         ).toEqual({
-            id: 1,
-            name: 'test',
-            extra: 'default',
-            more: 42,
+            foo: 'default', // 'foo' is known and allowed-optional, so this will be implicit-undefined
+            bar: undefined, // 'bar' is ignored so the explicit-undefined will override here
         });
     });
 });

--- a/src/object.js
+++ b/src/object.js
@@ -185,7 +185,7 @@ export function inexact<O: { +[field: string]: AnyDecoder }>(
     return compose(pojo, (blob: {| [string]: mixed |}) => {
         const allkeys = new Set(Object.keys(blob));
         const decoder = map(object(mapping), (safepart: $ObjMap<O, $DecoderType>) => {
-            const safekeys = new Set(Object.keys(safepart));
+            const safekeys = new Set(Object.keys(mapping));
 
             // To account for hard-coded keys that aren't part of the input
             for (const k of safekeys) {
@@ -194,7 +194,14 @@ export function inexact<O: { +[field: string]: AnyDecoder }>(
 
             const rv = {};
             for (const k of allkeys) {
-                rv[k] = safekeys.has(k) ? safepart[k] : blob[k];
+                if (safekeys.has(k)) {
+                    const value = safepart[k];
+                    if (value !== undefined) {
+                        rv[k] = value;
+                    }
+                } else {
+                    rv[k] = blob[k];
+                }
             }
             return rv;
         });

--- a/src/object.js
+++ b/src/object.js
@@ -95,10 +95,13 @@ export function object<O: { +[field: string]: AnyDecoder, ... }>(
         // will type the value part as "mixed"
         for (const key of Object.keys(mapping)) {
             const decoder = mapping[key];
-            const value = blob[key];
-            const result = decoder(value);
+            const rawValue = blob[key];
+            const result = decoder(rawValue);
             try {
-                record[key] = result.unwrap();
+                const value = result.unwrap();
+                if (value !== undefined) {
+                    record[key] = value;
+                }
 
                 // If this succeeded, remove the key from the missing keys
                 // tracker
@@ -111,7 +114,7 @@ export function object<O: { +[field: string]: AnyDecoder, ... }>(
 
                 // Keep track of the annotation, but don't return just yet. We
                 // want to collect more error information.
-                if (value === undefined) {
+                if (rawValue === undefined) {
                     // Explicitly add it to the missing set if the value is
                     // undefined.  This covers explicit undefineds to be
                     // treated the same as implicit undefineds (aka missing


### PR DESCRIPTION
Makes all decoders from the object family (`object()`, `exact()` and `inexact()`) return optional fields as implicit-undefined rather than explicit-undefined. This allows spreading the results of these values into an object with default values.

Fixes #573.
