### PR TITLE
Dispatch with on fields that are numbers

### DIFF
--- a/src/__tests__/dispatch.test.js
+++ b/src/__tests__/dispatch.test.js
@@ -38,9 +38,9 @@ const circle: Decoder<Circle> = object({
 });
 
 describe('dispatch', () => {
-    const decoder = dispatch('type', { rectangle, circle });
-
     it('allows conditional decoding', () => {
+        const decoder = dispatch('type', { rectangle, circle });
+
         const r = { type: 'rectangle', x: 3, y: 5, width: 80, height: 100 };
         expect(guard(decoder)(r)).toEqual(r);
 
@@ -49,6 +49,8 @@ describe('dispatch', () => {
     });
 
     it('invalid', () => {
+        const decoder = dispatch('type', { rectangle, circle });
+
         expect(() => guard(decoder)('foo')).toThrow('Must be an object');
         expect(() => guard(decoder)({})).toThrow('Missing key: "type"');
         expect(() => guard(decoder)({ type: 'blah' })).toThrow(
@@ -57,5 +59,21 @@ describe('dispatch', () => {
         expect(() => guard(decoder)({ type: 'rectangle', x: 1 })).toThrow(
             /Missing keys: "y", "width", "height"/
         );
+    });
+
+    it('allows using numbers as keys', () => {
+        const FooType = 0;
+        const BarType = 1;
+
+        const decoder = dispatch('type', {
+            [FooType]: object({ type: constant(FooType) }),
+            [BarType]: object({ type: constant(BarType) }),
+        });
+
+        const f = { type: FooType };
+        expect(guard(decoder)(f)).toEqual({ type: FooType });
+
+        const b = { type: BarType };
+        expect(guard(decoder)(b)).toEqual({ type: BarType });
     });
 });

--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -1,12 +1,12 @@
 // @flow strict
 
 import { oneOf } from './either';
+import { either } from './either';
+import { number } from './number';
 import { object } from './object';
 import { string } from './string';
-import { number } from './number';
-import { either } from './either';
-import { compose, map } from './utils';
 import type { $DecoderType, Decoder } from './types';
+import { compose, map } from './utils';
 
 // $FlowFixMe[unclear-type] (not really an issue) - deliberate use of `any` - not sure how we should get rid of this
 type anything = any;


### PR DESCRIPTION
The `dispatch` decoder does not work when the field is a number rather than a string. 

We are using the "keys" of the mapping object to reconcile the field type. Property names are strings by definition, numbers are automatically converted to strings via toString(). For Example below, keys equals ['0'], not [0].

```ts
const obj = { [0]: 'foo' };
const keys = Object.keys(obj);
```

oneOf will fail unless we run toString to the field in the decoded object also. 

I added a test case and made the fix.