### PR TITLE
Add new decoder: `describe()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.25.0
+
+-   **New decoders:**
+    -   [`describe`](https://github.com/nvie/decoders#describe): change the error message
+        for an existing decoder
+
 ## v1.24.0
 
 -   Drop support for Node 13.x (unstable)

--- a/README.md
+++ b/README.md
@@ -859,6 +859,24 @@ specific values that will be allowed at runtime.
 
 ---
 
+<a name="describe" href="#describe">#</a>
+<b>describe</b><i>&lt;T&gt;</i>(<i>Decoder&lt;T&gt;</i>, <i>string</i>):
+<i>Decoder&lt;T&gt;</i>
+[&lt;&gt;](https://github.com/nvie/decoders/blob/master/src/describe.js 'Source')<br />
+
+Defers to the given decoder, but when a decoding error happens, replace the error message
+with the given one. This can be used to simplify or shorten otherwise long or
+low-level/technical errors.
+
+```javascript
+const vowel = describe(
+    either5(constant('a'), constant('e'), constant('i'), constant('o'), constant('u')),
+    'Must be vowel'
+);
+```
+
+---
+
 <a name="lazy" href="#lazy">#</a> <b>lazy</b><i>&lt;T&gt;</i>(() =>
 <i>Decoder&lt;T&gt;</i>): <i>Decoder&lt;T&gt;</i>
 [&lt;&gt;](https://github.com/nvie/decoders/blob/master/src/lazy.js 'Source')<br />

--- a/src/__tests__/describe.test.js
+++ b/src/__tests__/describe.test.js
@@ -1,9 +1,7 @@
 // @flow strict
 
 import { constant } from '../constants';
-import {
-    describe as describe_,
-} from '../describe';
+import { describe as describe_ } from '../describe';
 import { either3 } from '../either';
 import { guard } from '../guard';
 

--- a/src/__tests__/describe.test.js
+++ b/src/__tests__/describe.test.js
@@ -1,0 +1,24 @@
+// @flow strict
+
+import { constant } from '../constants';
+import {
+    describe as describe_,
+} from '../describe';
+import { either3 } from '../either';
+import { guard } from '../guard';
+
+describe('describe', () => {
+    const verify = guard(
+        describe_(either3(constant('a'), constant('b'), constant('c')), 'Must be ABC')
+    );
+
+    it('valid', () => {
+        expect(verify('a')).toBe('a');
+        expect(verify('b')).toBe('b');
+        expect(verify('c')).toBe('c');
+    });
+
+    it('invalid', () => {
+        expect(() => verify('invalid')).toThrow(/Must be ABC/);
+    });
+});

--- a/src/describe.js
+++ b/src/describe.js
@@ -1,0 +1,17 @@
+// @flow strict
+
+import { annotate } from 'debrief';
+
+import type { Decoder } from './types';
+
+/**
+ * Wrap another decoder, and override the error message in case it fails. This
+ * is useful to "simplify" otherwise potentially complex error messages, or to
+ * use language in those error messages that can be relayed to end users (for
+ * example to show in form errors).
+ */
+export function describe<T>(decoder: Decoder<T>, message: string): Decoder<T> {
+    return (blob: mixed) => {
+        return decoder(blob).mapError((err) => annotate(err, message));
+    };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export { array, nonEmptyArray, poja } from './array';
 export { boolean, numericBoolean, truthy } from './boolean';
 export { constant, hardcoded, mixed, null_, undefined_, unknown } from './constants';
 export { date, iso8601 } from './date';
+export { describe } from './describe';
 export { dispatch } from './dispatch';
 export {
     either,

--- a/src/types/describe.d.ts
+++ b/src/types/describe.d.ts
@@ -1,0 +1,3 @@
+import { Decoder } from './types';
+
+export function describe<T>(decoder: Decoder<T>, msg: string): Decoder<T>;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,6 +7,7 @@ export { array, poja } from './array';
 export { boolean, numericBoolean, truthy } from './boolean';
 export { constant, hardcoded, mixed, null_, undefined_, unknown } from './constants';
 export { date, iso8601 } from './date';
+export { describe } from './describe';
 export { dispatch } from './dispatch';
 export {
     either,


### PR DESCRIPTION
Signature:
```
function describe<T>(decoder: Decoder<T>, errmsg: string): Decoder<T>
```

Defers to the given decoder, but when a decoding error happens, replace the error message with the given one. This can be used to simplify or shorten otherwise long or low-level/technical errors.

Example:

```javascript
const vowel = describe(
    either5(constant('a'), constant('e'), constant('i'), constant('o'), constant('u')),
    'Must be vowel'
);
```
