### PR TITLE
TS type-inference for constant() and hardcoded() scalars

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,18 +294,6 @@ mydecoder('hello world'); // DecodeError
 
 Returns a decoder capable of decoding just the given constant value.
 
-**NOTE:** In TypeScript, it is important to always use the following:
-
-```typescript
-// ❌ Do NOT do this
-constant('hello')           // will infer: Decoder<string>
-constant(42)                // will infer: Decoder<number>
-
-// ✅ Do this
-constant('hello' as const);  // will infer: Decoder<'hello'>
-constant(42 as const);       // will infer: Decoder<42>
-```
-
 For Flow, use this syntax:
 
 ```javascript
@@ -316,7 +304,7 @@ constant((42: 42));
 Example:
 
 ```typescript
-const mydecoder = guard(constant('hello' as const));
+const mydecoder = guard(constant('hello'));
 mydecoder('hello') === 'hello';
 mydecoder('this breaks'); // DecodeError
 mydecoder(false); // DecodeError

--- a/src/types/constants-tests.ts
+++ b/src/types/constants-tests.ts
@@ -1,14 +1,7 @@
 import { constant, hardcoded, mixed, null_, undefined_, unknown } from 'decoders';
 
-constant('foo' as const); // $ExpectType Decoder<"foo", unknown>
-// NOTE!       ^^^^^^^^
-//             This should _NOT_ be necessary!
-//             I want to get rid of this, but I'm not sure how to!
-
-hardcoded('foo' as const); // $ExpectType Decoder<"foo", unknown>
-// NOTE!        ^^^^^^^^
-//              This should _NOT_ be necessary!
-//              I want to get rid of this, but I'm not sure how to!
+constant('foo'); // $ExpectType Decoder<"foo", unknown>
+hardcoded('foo'); // $ExpectType Decoder<"foo", unknown>
 
 null_; // $ExpectType Decoder<null, unknown>
 undefined_; // $ExpectType Decoder<undefined, unknown>

--- a/src/types/constants.d.ts
+++ b/src/types/constants.d.ts
@@ -1,10 +1,13 @@
 import { Decoder } from './types';
+import { Scalar } from './either';
 
 // Constants
 
 export const null_: Decoder<null>;
 export const undefined_: Decoder<undefined>;
+export function constant<T extends Scalar>(value: T): Decoder<T>;
 export function constant<T>(value: T): Decoder<T>;
+export function hardcoded<T extends Scalar>(value: T): Decoder<T>;
 export function hardcoded<T>(value: T): Decoder<T>;
 export const mixed: Decoder<unknown>;
 export const unknown: Decoder<unknown>;

--- a/src/types/constants.d.ts
+++ b/src/types/constants.d.ts
@@ -6,7 +6,6 @@ import { Scalar } from './either';
 export const null_: Decoder<null>;
 export const undefined_: Decoder<undefined>;
 export function constant<T extends Scalar>(value: T): Decoder<T>;
-export function constant<T>(value: T): Decoder<T>;
 export function hardcoded<T extends Scalar>(value: T): Decoder<T>;
 export function hardcoded<T>(value: T): Decoder<T>;
 export const mixed: Decoder<unknown>;


### PR DESCRIPTION
Applies the workaround from #704 to `constant()` and `hardcoded()`, allowing us to write `constant('hello')` and get the correct type-inference (instead of `constant('hello' as const)`).