### PR TITLE
chore (docs): uncomment error message formatting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -152,8 +152,6 @@ tell you what inputs it accepts.
 You are encouraged to build your own decoders that serve your use case. For documentation
 and examples, see [Building your own](/building-your-own.md).
 
-<!--
-
 ## Formatting error messsages
 
 By default, `.verify()` will use the `formatInline` error formatter. You can pass another
@@ -202,5 +200,3 @@ Built-in formatters are:
     ```text
     Decoding error: Value at keypath 0.age: Must be number
     ```
-
--->


### PR DESCRIPTION
This content is really useful and took a long time and digging to find since it's not documented anywhere else. Why was it commented out?