### PR TITLE
Fix: allow implicitly-undefined values in JSONObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v2.0.1
 
+-   ![](./docs/assets/tiny-ts-logo.png) **TypeScript-only:** Fix definition of JSONObject
+    to reflect that its values might always be `undefined` as well.
+
 -   ![](./docs/assets/tiny-ts-logo.png) **TypeScript-only:** Changed return types of
     `{ [key: string]: T }` to `Record<string, T>`.
 

--- a/src/types/lib/json.d.ts
+++ b/src/types/lib/json.d.ts
@@ -2,7 +2,7 @@ import { Decoder } from '../Decoder';
 
 export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
 export interface JSONObject {
-    [key: string]: JSONValue;
+    [key: string]: JSONValue | undefined;
 }
 export type JSONArray = JSONValue[];
 

--- a/src/types/tests/typescript-inference-test.ts
+++ b/src/types/tests/typescript-inference-test.ts
@@ -272,6 +272,7 @@ test(lazy(() => number)); // $ExpectType number
 test(json); // $ExpectType JSONValue
 test(jsonObject); // $ExpectType JSONObject
 test(jsonArray); // $ExpectType JSONArray
+test(jsonObject).abc; // $ExpectType JSONValue | undefined
 
 {
     interface Animal {


### PR DESCRIPTION
The `JSONObject` type definitions holds a bug in the TypeScript definition.

```ts
import type { JSONObject } from 'decoders';

let o: JSONObject = { a: 1, b: 'hi' };
o.a   // JSONValue
o.b   // JSONValue
o.c   // JSONValue  <— a lie! it's actually `undefined`
```

The last example here illustrates the bug.
