### PR TITLE
Implements a new `select()` decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 **New decoders:**
 
-- `bigint`
-- `nullish` (replaces `maybe`)
+- `select()` (see [docs](https://decoders.cc/api.html#select))
+- `bigint` (see [docs](https://decoders.cc/api.html#bigint))
+- `nullish()` (see [docs](https://decoders.cc/api.html#nullish), replaces `maybe()`)
 
 **New features:**
 
@@ -11,9 +12,9 @@
 
 **Deprecated decoders:**
 
-- `hardcoded` (prefer `always`)
+- `hardcoded()` (prefer `always()`)
 - `mixed` (prefer `unknown`)
-- `maybe` (prefer `nullish`)
+- `maybe()` (prefer `nullish()`)
 
 **Other changes:**
 

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -44,7 +44,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L159-L171 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L160-L172 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -69,7 +69,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L173-L183 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L174-L184 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -95,7 +95,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L147-L157 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L148-L158 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -117,7 +117,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L185-L193 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L186-L194 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -137,7 +137,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L195-L208 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L196-L209 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -162,7 +162,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L236-L254 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L237-L255 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -195,7 +195,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L256-L273 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L257-L274 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -207,7 +207,7 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L210-L234 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L211-L235 'Source')
 {: #then .signature}
 
 Chain together the current decoder with another.
@@ -228,5 +228,5 @@ about its input and avoid re-refining inputs.
 If it helps, you can think of `define(...)` as equivalent to
 `unknown.then(...)`.
 
-<!--[[[end]]] (checksum: 6004e2372ff0815813ac42694e865c17) -->
+<!--[[[end]]] (checksum: 2017e386f9661b9f8688721bb56afe71) -->
 <!-- prettier-ignore-end -->

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -44,7 +44,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L155-L167 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L159-L171 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -69,7 +69,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L169-L179 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L173-L183 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -95,7 +95,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L143-L153 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L147-L157 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -117,7 +117,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L181-L189 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L185-L193 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -137,7 +137,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L191-L204 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L195-L208 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -162,7 +162,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L232-L250 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L236-L254 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -195,7 +195,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L252-L269 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L256-L273 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -207,7 +207,7 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L206-L230 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L210-L234 'Source')
 {: #then .signature}
 
 Chain together the current decoder with another.
@@ -228,5 +228,5 @@ about its input and avoid re-refining inputs.
 If it helps, you can think of `define(...)` as equivalent to
 `unknown.then(...)`.
 
-<!--[[[end]]] (checksum: 22e0103769740b5d37a58d95e086a55c) -->
+<!--[[[end]]] (checksum: 6004e2372ff0815813ac42694e865c17) -->
 <!-- prettier-ignore-end -->

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -953,6 +953,35 @@ DECODERS = {
     # """,
   },
 
+  'select': {
+    'section': 'Unions',
+    'type_params': ['T', 'A', 'B', '...'],
+    'params': [
+      ('scout', 'Decoder<T>'),
+      ('selectFn', '(result: T) => Decoder<A> | Decoder<B> | ...'),
+    ],
+    'return_type': 'Decoder<A | B | ...>',
+    'example': """
+    ```typescript
+    const decoder = select(
+      // First, validate/extract the minimal information to make a decision
+      object({ version: optional(number) }),
+
+      // Then select which decoder to run
+      (obj) => {
+        switch (obj.version) {
+          case undefined: return v1Decoder; // Suppose v1 doesn't have a discriminating field
+          case 2:         return v2Decoder;
+          case 3:         return v3Decoder;
+          default:        return never('Invalid version');
+        }
+      },
+    );
+    // Decoder<V1 | V2 | V3>
+    ```
+    """,
+  },
+
   'define': {
     'section': 'Utilities',
     'type_params': ['T'],

--- a/docs/api.md
+++ b/docs/api.md
@@ -1226,7 +1226,7 @@ try all decoders one by one.
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L129-L303 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L133-L302 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1369,5 +1369,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 4e2b484d2fba403a268d7d0dc8ac95bc)-->
+<!--[[[end]]] (checksum: 20580334825eb867cdb0ad426ed5e8b0)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,9 +37,9 @@ for section, names in DECODERS_BY_SECTION.items():
 - [**Arrays**](#arrays): [`array()`](/api.html#array), [`nonEmptyArray()`](/api.html#nonEmptyArray), [`poja`](/api.html#poja), [`tuple()`](/api.html#tuple), [`set()`](/api.html#set)
 - [**Objects**](#objects): [`object()`](/api.html#object), [`exact()`](/api.html#exact), [`inexact()`](/api.html#inexact), [`pojo`](/api.html#pojo), [`dict()`](/api.html#dict), [`mapping()`](/api.html#mapping)
 - [**JSON values**](#json-values): [`json`](/api.html#json), [`jsonObject`](/api.html#jsonObject), [`jsonArray`](/api.html#jsonArray)
-- [**Unions**](#unions): [`either()`](/api.html#either), [`oneOf()`](/api.html#oneOf), [`taggedUnion()`](/api.html#taggedUnion)
+- [**Unions**](#unions): [`either()`](/api.html#either), [`oneOf()`](/api.html#oneOf), [`taggedUnion()`](/api.html#taggedUnion), [`select()`](/api.html#select)
 - [**Utilities**](#utilities): [`define()`](/api.html#define), [`prep()`](/api.html#prep), [`never`](/api.html#never), [`instanceOf()`](/api.html#instanceOf), [`lazy()`](/api.html#lazy), [`fail`](/api.html#fail)
-<!--[[[end]]] (checksum: abe01c14cfde45ddf744d4a0f986c304) -->
+<!--[[[end]]] (checksum: 2bb03add0cc4785ee4a1bc1e25c66ddd) -->
 
 <!--[[[cog
 for section, names in DECODERS_BY_SECTION.items():
@@ -1124,6 +1124,7 @@ jsonArray.verify(null);               // throws
 - [`either()`](/api.html#either)
 - [`oneOf()`](/api.html#oneOf)
 - [`taggedUnion()`](/api.html#taggedUnion)
+- [`select()`](/api.html#select)
 
 ---
 
@@ -1214,6 +1215,37 @@ try all decoders one by one.
 
 ---
 
+<a href="#select">#</a> **select**&lt;<i style="color: #267f99">T</i>, <i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(scout: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>, selectFn: <i style="color: #267f99">(result: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt; | ...</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L141-L158 'Source')
+{: #select .signature}
+
+Briefly peek at a runtime input using a "scout" decoder first, then decide
+which decoder to run on the (original) input, based on the information that
+the "scout" extracted.
+
+It serves a similar purpose as [`taggedUnion()`](/api.html#taggedUnion), but is a generalization that
+works even if there isn't a single discriminator, or the discriminator isn't
+a string.
+
+```typescript
+const decoder = select(
+  // First, validate/extract the minimal information to make a decision
+  object({ version: optional(number) }),
+
+  // Then select which decoder to run
+  (obj) => {
+    switch (obj.version) {
+      case undefined: return v1Decoder; // Suppose v1 doesn't have a discriminating field
+      case 2:         return v2Decoder;
+      case 3:         return v3Decoder;
+      default:        return never('Invalid version');
+    }
+  },
+);
+// Decoder<V1 | V2 | V3>
+```
+
+---
+
 ## Utilities
 
 
@@ -1226,7 +1258,7 @@ try all decoders one by one.
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L133-L302 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L134-L304 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1369,5 +1401,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 20580334825eb867cdb0ad426ed5e8b0)-->
+<!--[[[end]]] (checksum: 5c969879f34b36cd42d207d50db00456)-->
 <!-- prettier-ignore-end -->

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -82,7 +82,8 @@ export interface Decoder<T> {
   /**
    * @internal
    * Chain together the current decoder with another acceptance function, but
-   * also pass along the original input.
+   * also pass along the original input. Don't call this method directly.
+   * You'll probably want to use the higher-level `select()` decoder instead.
    */
   peek<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V>;
 }
@@ -279,7 +280,8 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
    * This is like `.then()`, but instead of this function receiving just
    * the decoded result ``T``, it also receives the original input.
    *
-   * This is an advanced, low-level, decoder.
+   * This is an advanced, low-level, decoder. Don't call this method directly.
+   * Use the `select()` decoder instead.
    */
   function peek<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V> {
     return define((blob, ok, err) => {

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -79,8 +79,12 @@ export interface Decoder<T> {
    */
   then<V>(next: AcceptanceFn<V, T>): Decoder<V>;
 
-  // Experimental APIs (please don't rely on these yet)
-  peek_UNSTABLE<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V>;
+  /**
+   * @internal
+   * Chain together the current decoder with another acceptance function, but
+   * also pass along the original input.
+   */
+  peek<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V>;
 }
 
 /**
@@ -269,18 +273,15 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
   }
 
   /**
-   * WARNING: This is an EXPERIMENTAL API that will likely change in the
-   * future. Please DO NOT rely on it.
-   *
-   * Chain together the current decoder with another, but also pass along
-   * the original input.
+   * Chain together the current decoder with another acceptance function, but
+   * also pass along the original input.
    *
    * This is like `.then()`, but instead of this function receiving just
    * the decoded result ``T``, it also receives the original input.
    *
    * This is an advanced, low-level, decoder.
    */
-  function peek_UNSTABLE<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V> {
+  function peek<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V> {
     return define((blob, ok, err) => {
       const result = decode(blob);
       return result.ok ? next([blob, result.value], ok, err) : result;
@@ -296,8 +297,6 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
     reject,
     describe,
     then,
-
-    // EXPERIMENTAL - please DO NOT rely on this method
-    peek_UNSTABLE,
+    peek,
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export {
   uuidv1,
   uuidv4,
 } from './strings';
-export { either, oneOf, taggedUnion } from './unions';
+export { either, oneOf, select, taggedUnion } from './unions';
 
 // Core functionality
 export type { Decoder, DecodeResult, DecoderType } from '~/core';

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -137,3 +137,22 @@ export function taggedUnion<
     return decoder.decode(blob);
   });
 }
+
+/**
+ * Briefly peek at a runtime input using a "scout" decoder first, then decide
+ * which decoder to run on the (original) input, based on the information that
+ * the "scout" extracted.
+ *
+ * It serves a similar purpose as `taggedUnion()`, but is a generalization that
+ * works even if there isn't a single discriminator, or the discriminator isn't
+ * a string.
+ */
+export function select<T, D extends Decoder<unknown>>(
+  scout: Decoder<T>,
+  selectFn: (result: T) => D,
+): Decoder<DecoderType<D>> {
+  return scout.peek(([blob, peekResult]) => {
+    const decoder = selectFn(peekResult);
+    return decoder.decode(blob);
+  }) as Decoder<DecoderType<D>>;
+}

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -129,13 +129,13 @@ export function taggedUnion<
   O extends Record<string, Decoder<unknown>>,
   T = DecoderType<O[keyof O]>,
 >(field: string, mapping: O): Decoder<T> {
-  const scout: Decoder<string> = object({
+  const scout = object({
     [field]: prep(String, oneOf(Object.keys(mapping))),
   }).transform((o) => o[field]);
-  return scout.peek(([blob, key]) => {
-    const decoder = mapping[key] as Decoder<T>;
-    return decoder.decode(blob);
-  });
+  return select(
+    scout, // peek...
+    (key) => mapping[key] as Decoder<T>, // ...then select
+  );
 }
 
 /**

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -129,10 +129,10 @@ export function taggedUnion<
   O extends Record<string, Decoder<unknown>>,
   T = DecoderType<O[keyof O]>,
 >(field: string, mapping: O): Decoder<T> {
-  const base: Decoder<string> = object({
+  const scout: Decoder<string> = object({
     [field]: prep(String, oneOf(Object.keys(mapping))),
   }).transform((o) => o[field]);
-  return base.peek_UNSTABLE(([blob, key]) => {
+  return scout.peek(([blob, key]) => {
     const decoder = mapping[key] as Decoder<T>;
     return decoder.decode(blob);
   });

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -43,6 +43,7 @@ import {
   positiveNumber,
   prep,
   regex,
+  select,
   set,
   string,
   taggedUnion,
@@ -409,6 +410,8 @@ const circle: Decoder<Circle> = object({
 });
 
 expectType<Shape>(test(taggedUnion('_type', { rect, circle })));
+
+expectType<Shape>(test(select(unknown, (_) => (Math.random() < 0.5 ? rect : circle))));
 
 interface Rect1 {
   _type: 0;

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -150,8 +150,6 @@ expectType<string | undefined>(string.value('dummy'));
 
 expectType<number>(test(string.then((value: string) => ok(value.length))));
 
-expectType<number>(test(string.peek_UNSTABLE(([_blob, value]) => ok(value.length))));
-
 expectType<string>(test(string.refine((s) => s.startsWith('x'), 'Must start with x')));
 
 expectType<string>(


### PR DESCRIPTION
This decoder allows you to briefly peek at a runtime input using a "scout" decoder first, then decide which _actual_ decoder to run on the (original) input, based on the information that the "scout" extracted.

It serves a similar purpose as `taggedUnion()`, but is a generalization that works even if there isn't a single discriminator, or the discriminator isn't a string:

```tsx
const decoder = select(
  // First, validate/extract the minimal information to make a decision
  object({ version: optional(number) }),

  // Then select which decoder to run
  (obj) => {
    switch (obj.version) {
      case undefined: return v1Decoder; // e.g. if v1 doesn't have a discriminating field
      case 2:         return v2Decoder;
      case 3:         return v3Decoder;
      default:        return never('Invalid version');
    }
  },
);
// Decoder<V1 | V2 | V3>
```
