### PR TITLE
Add `enum_` decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 **New decoders:**
 
+- `enum_` (see [docs](https://decoders.cc/api.html#enum_))
+- `select()` (see [docs](https://decoders.cc/api.html#select))
 - `bigint` (see [docs](https://decoders.cc/api.html#bigint))
 - `decimal` (see [docs](https://decoders.cc/api.html#decimal))
 - `hexadecimal` (see [docs](https://decoders.cc/api.html#hexadecimal))
 - `numeric` (see [docs](https://decoders.cc/api.html#numeric))
-- `select()` (see [docs](https://decoders.cc/api.html#select))
 
 **Renamed decoders:**
 

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -954,6 +954,69 @@ DECODERS = {
     """,
   },
 
+  'enum_': {
+    'section': 'Unions',
+    'signatures': [
+      {
+        'params': [('enum', 'MyEnum')],
+        'return_type': 'Decoder<MyEnum>',
+      },
+    ],
+    'example': """
+      It works with numeric enums:
+
+      ```ts
+      enum Fruit {
+        Apple,
+        Banana,
+        Cherry
+      }
+
+      const decoder = enum_(Fruit);
+
+      // 👍
+      decoder.verify(Fruit.Apple) === Fruit.Apple;
+      decoder.verify(Fruit.Banana) === Fruit.Banana;
+      decoder.verify(Fruit.Cherry) === Fruit.Cherry;
+      decoder.verify(0) === Fruit.Apple;
+      decoder.verify(1) === Fruit.Banana;
+      decoder.verify(2) === Fruit.Cherry;
+
+      // 👎
+      decoder.verify('Apple');  // throws
+      decoder.verify(-1);       // throws
+      decoder.verify(3);        // throws
+      ```
+
+      As well as with string enums:
+
+      ```ts
+      enum Fruit {
+        Apple = 'a',
+        Banana = 'b',
+        Cherry = 'c'
+      }
+
+      const decoder = enum_(Fruit);
+
+      // 👍
+      decoder.verify(Fruit.Apple) === Fruit.Apple;
+      decoder.verify(Fruit.Banana) === Fruit.Banana;
+      decoder.verify(Fruit.Cherry) === Fruit.Cherry;
+      decoder.verify('a') === Fruit.Apple;
+      decoder.verify('b') === Fruit.Banana;
+      decoder.verify('c') === Fruit.Cherry;
+
+      // 👎
+      decoder.verify('Apple');  // throws
+      decoder.verify(0);        // throws
+      decoder.verify(1);        // throws
+      decoder.verify(2);        // throws
+      decoder.verify(3);        // throws
+      ```
+    """,
+  },
+
   'taggedUnion': {
     'section': 'Unions',
     'type_params': ['A', 'B', '...'],

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,9 +37,9 @@ for section, names in DECODERS_BY_SECTION.items():
 - [**Arrays**](#arrays): [`array()`](/api.html#array), [`nonEmptyArray()`](/api.html#nonEmptyArray), [`poja`](/api.html#poja), [`tuple()`](/api.html#tuple), [`set()`](/api.html#set)
 - [**Objects**](#objects): [`object()`](/api.html#object), [`exact()`](/api.html#exact), [`inexact()`](/api.html#inexact), [`pojo`](/api.html#pojo), [`dict()`](/api.html#dict), [`mapping()`](/api.html#mapping)
 - [**JSON values**](#json-values): [`json`](/api.html#json), [`jsonObject`](/api.html#jsonObject), [`jsonArray`](/api.html#jsonArray)
-- [**Unions**](#unions): [`either()`](/api.html#either), [`oneOf()`](/api.html#oneOf), [`taggedUnion()`](/api.html#taggedUnion), [`select()`](/api.html#select)
+- [**Unions**](#unions): [`either()`](/api.html#either), [`oneOf()`](/api.html#oneOf), [`enum_()`](/api.html#enum_), [`taggedUnion()`](/api.html#taggedUnion), [`select()`](/api.html#select)
 - [**Utilities**](#utilities): [`define()`](/api.html#define), [`prep()`](/api.html#prep), [`never`](/api.html#never), [`instanceOf()`](/api.html#instanceOf), [`lazy()`](/api.html#lazy), [`fail`](/api.html#fail)
-<!--[[[end]]] (checksum: 31c937e1960485cba47c0873f74e1b02) -->
+<!--[[[end]]] (checksum: 4623c37c1951846290664e89d0c8120a) -->
 
 <!--[[[cog
 for section, names in DECODERS_BY_SECTION.items():
@@ -99,7 +99,7 @@ for section, names in DECODERS_BY_SECTION.items():
 
 ---
 
-<a href="#string">#</a> **string**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L17-L22 'Source')
+<a href="#string">#</a> **string**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L18-L23 'Source')
 {: #string .signature}
 
 Accepts and returns strings.
@@ -118,7 +118,7 @@ string.verify(null);  // throws
 
 ---
 
-<a href="#nonEmptyString">#</a> **nonEmptyString**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L24-L27 'Source')
+<a href="#nonEmptyString">#</a> **nonEmptyString**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L25-L28 'Source')
 {: #nonEmptyString .signature}
 
 Like [`string`](/api.html#string), but will reject the empty string or strings containing only whitespace.
@@ -136,7 +136,7 @@ nonEmptyString.verify('');    // throws
 
 ---
 
-<a href="#regex">#</a> **regex**(pattern: <i style="color: #267f99">RegExp</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L29-L34 'Source')
+<a href="#regex">#</a> **regex**(pattern: <i style="color: #267f99">RegExp</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L30-L35 'Source')
 {: #regex .signature}
 
 Accepts and returns strings that match the given regular expression.
@@ -156,7 +156,7 @@ decoder.verify('foo');  // throws
 
 ---
 
-<a href="#decimal">#</a> **decimal**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L91-L95 'Source')
+<a href="#decimal">#</a> **decimal**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L92-L96 'Source')
 {: #decimal .signature}
 
 Accepts and returns strings with decimal digits only (base-10).
@@ -178,7 +178,7 @@ decoder.verify(123);       // throws (not a string)
 
 ---
 
-<a href="#hexadecimal">#</a> **hexadecimal**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L97-L103 'Source')
+<a href="#hexadecimal">#</a> **hexadecimal**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L98-L104 'Source')
 {: #hexadecimal .signature}
 
 Accepts and returns strings with hexadecimal digits only (base-16).
@@ -198,7 +198,7 @@ decoder.verify('1');    // throws
 
 ---
 
-<a href="#numeric">#</a> **numeric**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L105-L110 'Source')
+<a href="#numeric">#</a> **numeric**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L106-L111 'Source')
 {: #numeric .signature}
 
 Accepts valid numerical strings (in base-10) and returns them as a number.
@@ -221,7 +221,7 @@ decoder.verify(123);       // throws (not a string)
 
 ---
 
-<a href="#email">#</a> **email**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L36-L44 'Source')
+<a href="#email">#</a> **email**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L37-L45 'Source')
 {: #email .signature}
 
 Accepts and returns strings that are syntactically valid email addresses.
@@ -239,7 +239,7 @@ email.verify('alice @ acme.org');  // throws
 
 ---
 
-<a href="#url">#</a> **url**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L46-L52 'Source')
+<a href="#url">#</a> **url**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L47-L53 'Source')
 {: #url .signature}
 
 Accepts strings that are valid URLs, returns the value as a URL instance.
@@ -259,7 +259,7 @@ url.verify('/search?q=foo');     // throws
 
 ---
 
-<a href="#httpsUrl">#</a> **httpsUrl**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L54-L61 'Source')
+<a href="#httpsUrl">#</a> **httpsUrl**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L55-L62 'Source')
 {: #httpsUrl .signature}
 
 Accepts strings that are valid URLs, but only HTTPS ones. Returns the value
@@ -285,7 +285,7 @@ const gitUrl: Decoder<URL> = url.refine(
 
 ---
 
-<a href="#uuid">#</a> **uuid**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L63-L71 'Source')
+<a href="#uuid">#</a> **uuid**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;string&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L64-L72 'Source')
 {: #uuid .signature}
 
 Accepts strings that are valid
@@ -304,7 +304,7 @@ uuid.verify('abcdefgh-ijkl-mnop-qrst-uvwxyz012345');  // throws
 
 ---
 
-<a href="#uuidv1">#</a> **uuidv1**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L73-L80 'Source')
+<a href="#uuidv1">#</a> **uuidv1**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L74-L81 'Source')
 {: #uuidv1 .signature}
 
 Like [`uuid`](/api.html#uuid), but only accepts
@@ -321,7 +321,7 @@ uuidv1.verify('123e4567-e89b-42d3-a456-426614174000')  // throws
 
 ---
 
-<a href="#uuidv4">#</a> **uuidv4**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L82-L89 'Source')
+<a href="#uuidv4">#</a> **uuidv4**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;URL&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/strings.ts#L83-L90 'Source')
 {: #uuidv4 .signature}
 
 Like [`uuid`](/api.html#uuid), but only accepts
@@ -350,7 +350,7 @@ uuidv4.verify('123e4567-e89b-12d3-a456-426614174000')  // throws
 
 ---
 
-<a href="#number">#</a> **number**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L15-L22 'Source')
+<a href="#number">#</a> **number**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L16-L23 'Source')
 {: #number .signature}
 
 Accepts finite numbers (can be integer or float values). Values `NaN`,
@@ -369,7 +369,7 @@ number.verify('not a number');  // throws
 
 ---
 
-<a href="#integer">#</a> **integer**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L24-L30 'Source')
+<a href="#integer">#</a> **integer**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L25-L31 'Source')
 {: #integer .signature}
 
 Accepts only finite whole numbers.
@@ -387,7 +387,7 @@ integer.verify('not a integer'); // throws
 
 ---
 
-<a href="#positiveNumber">#</a> **positiveNumber**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L32-L37 'Source')
+<a href="#positiveNumber">#</a> **positiveNumber**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L33-L38 'Source')
 {: #positiveNumber .signature}
 
 Accepts only non-negative (zero or positive) finite numbers.
@@ -408,7 +408,7 @@ positiveNumber.verify('not a number');  // throws
 
 ---
 
-<a href="#positiveInteger">#</a> **positiveInteger**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L39-L44 'Source')
+<a href="#positiveInteger">#</a> **positiveInteger**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L40-L45 'Source')
 {: #positiveInteger .signature}
 
 Accepts only non-negative (zero or positive) finite whole numbers.
@@ -429,7 +429,7 @@ positiveInteger.verify('not a number');  // throws
 
 ---
 
-<a href="#anyNumber">#</a> **anyNumber**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L4-L13 'Source')
+<a href="#anyNumber">#</a> **anyNumber**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;number&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L5-L14 'Source')
 {: #anyNumber .signature}
 
 Accepts any valid ``number`` value.
@@ -451,7 +451,7 @@ anyNumber.verify('not a number');  // throws
 
 ---
 
-<a href="#bigint">#</a> **bigint**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;bigint&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L46-L51 'Source')
+<a href="#bigint">#</a> **bigint**: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;bigint&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/numbers.ts#L47-L52 'Source')
 {: #bigint .signature}
 
 Accepts any valid ``bigint`` value.
@@ -1180,12 +1180,13 @@ jsonArray.verify(null);               // throws
 
 - [`either()`](/api.html#either)
 - [`oneOf()`](/api.html#oneOf)
+- [`enum_()`](/api.html#enum_)
 - [`taggedUnion()`](/api.html#taggedUnion)
 - [`select()`](/api.html#select)
 
 ---
 
-<a href="#either">#</a> **either**&lt;<i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(<i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt;</i>, <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt;</i>, <i style="color: #267f99">...</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L49-L82 'Source')
+<a href="#either">#</a> **either**&lt;<i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(<i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt;</i>, <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt;</i>, <i style="color: #267f99">...</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L50-L83 'Source')
 {: #either .signature}
 
 Accepts values accepted by any of the given decoders.
@@ -1207,7 +1208,7 @@ decoder.verify(false);  // throws
 
 ---
 
-<a href="#oneOf">#</a> **oneOf**&lt;<i style="color: #267f99">T</i>&gt;(values: <i style="color: #267f99">T[]</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L84-L98 'Source')
+<a href="#oneOf">#</a> **oneOf**&lt;<i style="color: #267f99">T</i>&gt;(values: <i style="color: #267f99">T[]</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L85-L99 'Source')
 {: #oneOf .signature}
 
 Accepts any value that is strictly-equal (using `===`) to one of the
@@ -1234,7 +1235,66 @@ oneOf(['foo', 'bar']);
 
 ---
 
-<a href="#taggedUnion">#</a> **taggedUnion**&lt;<i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(field: <i style="color: #267f99">string</i>, mapping: <i style="color: #267f99">{ value1: <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt;, value2: <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt;, ... }</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L100-L139 'Source')
+<a href="#enum_">#</a> **enum_**(enum: <i style="color: #267f99">MyEnum</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;MyEnum&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L101-L122 'Source')
+{: #enum_ .signature}
+
+Accepts and return an enum value.
+
+It works with numeric enums:
+
+```ts
+enum Fruit {
+  Apple,
+  Banana,
+  Cherry
+}
+
+const decoder = enum_(Fruit);
+
+// 👍
+decoder.verify(Fruit.Apple) === Fruit.Apple;
+decoder.verify(Fruit.Banana) === Fruit.Banana;
+decoder.verify(Fruit.Cherry) === Fruit.Cherry;
+decoder.verify(0) === Fruit.Apple;
+decoder.verify(1) === Fruit.Banana;
+decoder.verify(2) === Fruit.Cherry;
+
+// 👎
+decoder.verify('Apple');  // throws
+decoder.verify(-1);       // throws
+decoder.verify(3);        // throws
+```
+
+As well as with string enums:
+
+```ts
+enum Fruit {
+  Apple = 'a',
+  Banana = 'b',
+  Cherry = 'c'
+}
+
+const decoder = enum_(Fruit);
+
+// 👍
+decoder.verify(Fruit.Apple) === Fruit.Apple;
+decoder.verify(Fruit.Banana) === Fruit.Banana;
+decoder.verify(Fruit.Cherry) === Fruit.Cherry;
+decoder.verify('a') === Fruit.Apple;
+decoder.verify('b') === Fruit.Banana;
+decoder.verify('c') === Fruit.Cherry;
+
+// 👎
+decoder.verify('Apple');  // throws
+decoder.verify(0);        // throws
+decoder.verify(1);        // throws
+decoder.verify(2);        // throws
+decoder.verify(3);        // throws
+```
+
+---
+
+<a href="#taggedUnion">#</a> **taggedUnion**&lt;<i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(field: <i style="color: #267f99">string</i>, mapping: <i style="color: #267f99">{ value1: <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt;, value2: <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt;, ... }</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L124-L163 'Source')
 {: #taggedUnion .signature}
 
 If you are decoding tagged unions you may want to use the [`taggedUnion()`](/api.html#taggedUnion)
@@ -1266,7 +1326,7 @@ try all decoders one by one.
 
 ---
 
-<a href="#select">#</a> **select**&lt;<i style="color: #267f99">T</i>, <i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(scout: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>, selectFn: <i style="color: #267f99">(result: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt; | ...</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L141-L158 'Source')
+<a href="#select">#</a> **select**&lt;<i style="color: #267f99">T</i>, <i style="color: #267f99">A</i>, <i style="color: #267f99">B</i>, <i style="color: #267f99">...</i>&gt;(scout: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>, selectFn: <i style="color: #267f99">(result: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;B&gt; | ...</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;A | B | ...&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/unions.ts#L165-L182 'Source')
 {: #select .signature}
 
 Briefly peek at a runtime input using a "scout" decoder first, then decide
@@ -1452,5 +1512,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: f48860313f1cb44f87a79bc50633ebc3)-->
+<!--[[[end]]] (checksum: 167f7d4fa7935ce2590166e430d75023)-->
 <!-- prettier-ignore-end -->

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export { dict, exact, inexact, mapping, object, pojo } from './objects';
 export { nonEmptyString, regex, string } from './strings';
 export { email, httpsUrl, url, uuid, uuidv1, uuidv4 } from './strings';
 export { decimal, hexadecimal, numeric } from './strings';
-export { either, oneOf, select, taggedUnion } from './unions';
+export { either, enum_, oneOf, select, taggedUnion } from './unions';
 
 // Core functionality
 export type { Decoder, DecodeResult, DecoderType } from '~/core';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,15 @@
+export function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}
+
+export function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+export function isBigInt(value: unknown): value is bigint {
+  return typeof value === 'bigint';
+}
+
 export function isDate(value: unknown): value is Date {
   //
   // `x instanceof Date` checks are unreliable across stack frames (that

--- a/src/numbers.ts
+++ b/src/numbers.ts
@@ -1,5 +1,6 @@
 import type { Decoder } from '~/core';
 import { define } from '~/core';
+import { isBigInt, isNumber } from '~/lib/utils';
 
 /**
  * Accepts any valid ``number`` value.
@@ -9,7 +10,7 @@ import { define } from '~/core';
  * `number` decoder instead.
  */
 export const anyNumber: Decoder<number> = define((blob, ok, err) =>
-  typeof blob === 'number' ? ok(blob) : err('Must be number'),
+  isNumber(blob) ? ok(blob) : err('Must be number'),
 );
 
 /**
@@ -47,5 +48,5 @@ export const positiveInteger: Decoder<number> = integer
  * Accepts any valid ``bigint`` value.
  */
 export const bigint: Decoder<bigint> = define((blob, ok, err) =>
-  typeof blob === 'bigint' ? ok(blob) : err('Must be bigint'),
+  isBigInt(blob) ? ok(blob) : err('Must be bigint'),
 );

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -1,9 +1,9 @@
 import type { Decoder } from '~/core';
 import { define } from '~/core';
+import { isString } from '~/lib/utils';
 
 import { instanceOf } from './misc';
 import { either } from './unions';
-import { isString } from '~/lib/utils';
 
 /** Match groups in this regex:
  * \1 - the scheme

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -3,6 +3,7 @@ import { define } from '~/core';
 
 import { instanceOf } from './misc';
 import { either } from './unions';
+import { isString } from '~/lib/utils';
 
 /** Match groups in this regex:
  * \1 - the scheme
@@ -18,7 +19,7 @@ const url_re =
  * Accepts and returns strings.
  */
 export const string: Decoder<string> = define((blob, ok, err) =>
-  typeof blob === 'string' ? ok(blob) : err('Must be string'),
+  isString(blob) ? ok(blob) : err('Must be string'),
 );
 
 /**

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -2,10 +2,10 @@ import type { Decoder, DecoderType } from '~/core';
 import { define, summarize } from '~/core';
 import { indent } from '~/lib/text';
 import type { Scalar } from '~/lib/types';
+import { isNumber, isString } from '~/lib/utils';
 
 import { prep } from './misc';
 import { object } from './objects';
-import { isNumber, isString } from '~/lib/utils';
 
 const EITHER_PREFIX = 'Either:\n';
 

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -5,6 +5,7 @@ import type { Scalar } from '~/lib/types';
 
 import { prep } from './misc';
 import { object } from './objects';
+import { isNumber, isString } from '~/lib/utils';
 
 const EITHER_PREFIX = 'Either:\n';
 
@@ -95,6 +96,29 @@ export function oneOf<C extends Scalar>(constants: readonly C[]): Decoder<C> {
       `Must be one of ${constants.map((value) => JSON.stringify(value)).join(', ')}`,
     );
   });
+}
+
+/**
+ * Accepts and return an enum value.
+ */
+export function enum_<TEnum extends Record<string, string | number>>(
+  enumObj: TEnum,
+): Decoder<TEnum[keyof TEnum]> {
+  const values = Object.values(enumObj);
+  if (!values.some(isNumber)) {
+    return oneOf(values) as Decoder<TEnum[keyof TEnum]>;
+  } else {
+    // Numeric enums (or mixed enums) require a bit more work. We'll definitely
+    // want to allow all the numeric values.
+    const nums = values.filter(isNumber);
+    const ignore = new Set(nums.map((val) => enumObj[val]));
+
+    // But don't keep the string values that are the key names for the
+    // numeric values we already covered
+    const strings = values.filter(isString).filter((val) => !ignore.has(val));
+
+    return oneOf([...nums, ...strings]) as Decoder<TEnum[keyof TEnum]>;
+  }
 }
 
 /**

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -12,6 +12,7 @@ import {
   dict,
   either,
   email,
+  enum_,
   exact,
   fail,
   hardcoded,
@@ -66,7 +67,7 @@ import {
   // Results
   ok,
 } from '../dist';
-import { expectError, expectType } from 'tsd';
+import { expectError, expectType, expectAssignable } from 'tsd';
 
 // Helper function to "test" a decoder on some input, and assert the return type
 function test<T>(decoder: Decoder<T>): T {
@@ -381,6 +382,33 @@ expectType<string>(
 );
 
 expectType<'foo' | 'bar'>(test(oneOf(['foo', 'bar'])));
+
+enum Fruit {
+  Apple = 'a',
+  Banana = 'b',
+  Cherry = 'c',
+}
+
+enum Primes {
+  Five = 5,
+  Three = 3,
+  Eleven = 11,
+}
+
+// Not sure why this isn't strictly expectType?
+// TypeScript thinks these aren't equal types.
+expectAssignable<Fruit>(test(enum_(Fruit)));
+expectAssignable<Primes>(test(enum_(Primes)));
+
+const ConstEnum = {
+  Five: 'five',
+  Three: 3,
+  Nine: 9,
+} as const;
+
+type MixedConstEnumType = (typeof ConstEnum)[keyof typeof ConstEnum];
+
+expectType<MixedConstEnumType>(test(enum_(ConstEnum)));
 
 interface Rect {
   _type: 'rect';

--- a/test/unions.test.ts
+++ b/test/unions.test.ts
@@ -267,6 +267,7 @@ describe('enums', () => {
   describe('string enums with duplicate values', () => {
     enum Fruit {
       Apple = 'apple',
+      // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
       AlsoApple = 'apple',
     }
 

--- a/test/unions.test.ts
+++ b/test/unions.test.ts
@@ -8,7 +8,7 @@ import type { Decoder } from '~/core';
 import { number } from '~/numbers';
 import { object } from '~/objects';
 import { regex, string } from '~/strings';
-import { either, oneOf, select, taggedUnion } from '~/unions';
+import { either, enum_, oneOf, select, taggedUnion } from '~/unions';
 
 import { INPUTS } from './_fixtures';
 
@@ -199,6 +199,210 @@ describe('oneOf', () => {
       const expected = okay.includes(blob as never);
       expect(decoder.decode(blob).ok).toBe(expected);
     }));
+});
+
+describe('enums', () => {
+  describe('string enums', () => {
+    enum Fruit {
+      Apple = 'apple',
+      Banana = 'banana',
+      Cherry = 'cherry',
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify(Fruit.Cherry)).toBe(Fruit.Cherry);
+      expect(decoder.verify('apple')).toBe(Fruit.Apple);
+      expect(decoder.verify('banana')).toBe(Fruit.Banana);
+      expect(decoder.verify('cherry')).toBe(Fruit.Cherry);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(
+        /Must be one of "apple", "banana", "cherry"/,
+      );
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('Banana')).toThrow();
+      expect(() => decoder.verify('Cherry')).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(1)).toThrow();
+      expect(() => decoder.verify(2)).toThrow();
+      expect(() => decoder.verify(3)).toThrow();
+    });
+  });
+
+  describe('string enums where keys and values are equal', () => {
+    enum Fruit {
+      Apple = 'Apple',
+      Banana = 'Banana',
+      Cherry = 'Cherry',
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify(Fruit.Cherry)).toBe(Fruit.Cherry);
+      expect(decoder.verify('Apple')).toBe(Fruit.Apple);
+      expect(decoder.verify('Banana')).toBe(Fruit.Banana);
+      expect(decoder.verify('Cherry')).toBe(Fruit.Cherry);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(
+        /Must be one of "Apple", "Banana", "Cherry"/,
+      );
+      expect(() => decoder.verify('Peach')).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(1)).toThrow();
+      expect(() => decoder.verify(2)).toThrow();
+      expect(() => decoder.verify(3)).toThrow();
+    });
+  });
+
+  describe('string enums with duplicate values', () => {
+    enum Fruit {
+      Apple = 'apple',
+      AlsoApple = 'apple',
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.AlsoApple)).toBe(Fruit.AlsoApple);
+      expect(decoder.verify('apple')).toBe(Fruit.Apple);
+      expect(decoder.verify('apple')).toBe(Fruit.AlsoApple);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(/Must be one of "apple", "apple"/);
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('AlsoApple')).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(1)).toThrow();
+      expect(() => decoder.verify(2)).toThrow();
+      expect(() => decoder.verify(3)).toThrow();
+    });
+  });
+
+  describe('numeric enums', () => {
+    enum Fruit {
+      Apple,
+      Banana,
+      Cherry,
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify(Fruit.Cherry)).toBe(Fruit.Cherry);
+      expect(decoder.verify(0)).toBe(Fruit.Apple);
+      expect(decoder.verify(1)).toBe(Fruit.Banana);
+      expect(decoder.verify(2)).toBe(Fruit.Cherry);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(/Must be one of 0, 1, 2/);
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('Banana')).toThrow();
+      expect(() => decoder.verify('Cherry')).toThrow();
+      expect(() => decoder.verify('apple')).toThrow();
+      expect(() => decoder.verify('banana')).toThrow();
+      expect(() => decoder.verify('cherry')).toThrow();
+      expect(() => decoder.verify(-1)).toThrow();
+      expect(() => decoder.verify(3)).toThrow();
+    });
+  });
+
+  describe('number enums with explicit auto-incrementing nums', () => {
+    enum Fruit {
+      Apple = 1,
+      Banana,
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify(1)).toBe(Fruit.Apple);
+      expect(decoder.verify(2)).toBe(Fruit.Banana);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(/Must be one of 1, 2/);
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('Banana')).toThrow();
+      expect(() => decoder.verify('apple')).toThrow();
+      expect(() => decoder.verify('banana')).toThrow();
+      expect(() => decoder.verify(-1)).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(3)).toThrow();
+    });
+  });
+
+  describe('number enums with explicit nums', () => {
+    enum Fruit {
+      Apple = 42,
+      Banana = 13,
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify(42)).toBe(Fruit.Apple);
+      expect(decoder.verify(13)).toBe(Fruit.Banana);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(/Must be one of 42, 13/);
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('Banana')).toThrow();
+      expect(() => decoder.verify('apple')).toThrow();
+      expect(() => decoder.verify('banana')).toThrow();
+      expect(() => decoder.verify(-1)).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(1)).toThrow();
+      expect(() => decoder.verify(2)).toThrow();
+    });
+  });
+
+  describe('mixed enums', () => {
+    enum Fruit {
+      Apple = 'apple',
+      Banana = 3,
+      Cherry = 'Cherry',
+    }
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify('apple')).toBe(Fruit.Apple);
+      expect(decoder.verify(3)).toBe(Fruit.Banana);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(/Must be one of 3, "apple", "Cherry"/);
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('Banana')).toThrow();
+      expect(() => decoder.verify('banana')).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(1)).toThrow();
+      expect(() => decoder.verify(2)).toThrow();
+      expect(() => decoder.verify(4)).toThrow();
+    });
+  });
 });
 
 type Rectangle = {

--- a/test/unions.test.ts
+++ b/test/unions.test.ts
@@ -403,6 +403,35 @@ describe('enums', () => {
       expect(() => decoder.verify(4)).toThrow();
     });
   });
+
+  describe('manual enum constants', () => {
+    const Fruit = {
+      Apple: 'apple',
+      Banana: 'banana',
+      Cherry: 3,
+    } as const;
+
+    const decoder = enum_(Fruit);
+
+    test('valid', () => {
+      expect(decoder.verify(Fruit.Apple)).toBe(Fruit.Apple);
+      expect(decoder.verify(Fruit.Banana)).toBe(Fruit.Banana);
+      expect(decoder.verify(Fruit.Cherry)).toBe(Fruit.Cherry);
+      expect(decoder.verify('apple')).toBe(Fruit.Apple);
+      expect(decoder.verify('banana')).toBe(Fruit.Banana);
+      expect(decoder.verify(3)).toBe(Fruit.Cherry);
+    });
+
+    test('invalid', () => {
+      expect(() => decoder.verify('xx')).toThrow(/Must be one of 3, "apple", "banana"/);
+      expect(() => decoder.verify('Apple')).toThrow();
+      expect(() => decoder.verify('Banana')).toThrow();
+      expect(() => decoder.verify(0)).toThrow();
+      expect(() => decoder.verify(1)).toThrow();
+      expect(() => decoder.verify(2)).toThrow();
+      expect(() => decoder.verify(4)).toThrow();
+    });
+  });
 });
 
 type Rectangle = {


### PR DESCRIPTION
It works with numeric enums:

```ts
enum Fruit {
  Apple,
  Banana,
  Cherry
}

const decoder = enum_(Fruit);

// 👍
decoder.verify(Fruit.Apple) === Fruit.Apple;
decoder.verify(Fruit.Banana) === Fruit.Banana;
decoder.verify(Fruit.Cherry) === Fruit.Cherry;
decoder.verify(0) === Fruit.Apple;
decoder.verify(1) === Fruit.Banana;
decoder.verify(2) === Fruit.Cherry;

// 👎
decoder.verify('Apple');  // throws
decoder.verify(-1);       // throws
decoder.verify(3);        // throws
```

As well as with string enums:

```ts
enum Fruit {
  Apple = 'a',
  Banana = 'b',
  Cherry = 'c'
}

const decoder = enum_(Fruit);

// 👍
decoder.verify(Fruit.Apple) === Fruit.Apple;
decoder.verify(Fruit.Banana) === Fruit.Banana;
decoder.verify(Fruit.Cherry) === Fruit.Cherry;
decoder.verify('a') === Fruit.Apple;
decoder.verify('b') === Fruit.Banana;
decoder.verify('c') === Fruit.Cherry;

// 👎
decoder.verify('Apple');  // throws
decoder.verify(0);        // throws
decoder.verify(1);        // throws
decoder.verify(2);        // throws
decoder.verify(3);        // throws
```

Also works with manual constant enums (not real TypeScript enums):

```ts
const Fruit = {
  Apple = 'a',
  Banana = 'b',
  Cherry = 'c'
} as const;

const decoder = enum_(Fruit);

// 👍
decoder.verify(Fruit.Apple) === Fruit.Apple;
decoder.verify(Fruit.Banana) === Fruit.Banana;
decoder.verify(Fruit.Cherry) === Fruit.Cherry;
decoder.verify('a') === Fruit.Apple;
decoder.verify('b') === Fruit.Banana;
decoder.verify('c') === Fruit.Cherry;

// 👎
decoder.verify('Apple');  // throws
decoder.verify(0);        // throws
decoder.verify(1);        // throws
decoder.verify(2);        // throws
decoder.verify(3);        // throws
```
