### PR TITLE
Rename `dict` → `record` and add two-argument form to also validate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Renamed decoders:**
 
+- `record()` (see [docs](https://decoders.cc/api.html#record), replaces `dict()`)
 - `nullish()` (see [docs](https://decoders.cc/api.html#nullish), replaces `maybe()`)
 
 **New features:**

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -824,15 +824,71 @@ DECODERS = {
 
   'record': {
     'section': 'Objects',
-    'type_params': ['T'],
-    'params': [('decoder', 'Decoder<T>')],
-    'return_type': 'Decoder<{ [key: string]: T }>',
-    'aliases': ['dict'],
+    'signatures': [
+      {
+        'type_params': ['V'],
+        'params': [('values', 'Decoder<V>')],
+        'return_type': 'Decoder<Record<string, V>>',
+        },
+      {
+        'type_params': ['K', 'V'],
+        'params': [('keys', 'Decoder<K>'), ('values', 'Decoder<V>')],
+        'return_type': 'Decoder<Record<K, V>>',}
+      ],
     'example': """
+      This is useful to validate inputs like `{ [key: string]: V }`.
+
+      #### Decoding values only
+
+      The default call takes a single argument and will validate all _values_.
+      For example, to validate that all values in the object are numbers:
+
+      ```ts
       const decoder = record(number);
+      //                        \ 
+      //                      Values must be numbers
 
       // 👍
-      decoder.verify({ red: 1, blue: 2, green: 3 }); // ≈ { red: 1, blue: 2, green: 3 }
+      decoder.verify({ red: 1, blue: 2, green: 3 });
+
+      // 👎
+      decoder.verify({ hi: 'not a number' });
+      ```
+
+      #### Decoding keys and values
+
+      If you also want to validate that keys are of a specific form, use the
+      two-argument form: `record(key, value)`. Note that the given key decoder
+      must return strings.
+
+      For example, to enforce that all keys are emails:
+
+      ```ts
+      const decoder = record(email, number);
+      //                      /        \ 
+      //              Keys must        Values must
+      //             be emails           be numbers
+
+      // 👍
+      decoder.verify({ "me@nvie.com": 1 });
+
+      // 👎
+      decoder.verify({ "no-email": 1 });
+      ```
+    """,
+  },
+
+  'dict': {
+    'section': 'Objects',
+    'signatures': [
+      {
+        'type_params': ['V'],
+        'params': [('decoder', 'Decoder<T>')],
+        'return_type': 'Decoder<Record<string, V>>',
+      }
+    ],
+    'markdown': """
+      Alias of `record()`.
     """,
   },
 

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -822,14 +822,14 @@ DECODERS = {
     """,
   },
 
-  # TODO: Rename to "record"
-  'dict': {
+  'record': {
     'section': 'Objects',
     'type_params': ['T'],
     'params': [('decoder', 'Decoder<T>')],
     'return_type': 'Decoder<{ [key: string]: T }>',
+    'aliases': ['dict'],
     'example': """
-      const decoder = dict(number);
+      const decoder = record(number);
 
       // 👍
       decoder.verify({ red: 1, blue: 2, green: 3 }); // ≈ { red: 1, blue: 2, green: 3 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,11 +35,11 @@ for section, names in DECODERS_BY_SECTION.items():
 - [**Constants**](#constants): [`constant()`](/api.html#constant), [`always()`](/api.html#always), [`hardcoded()`](/api.html#hardcoded)
 - [**Optionality**](#optionality): [`null_`](/api.html#null_), [`undefined_`](/api.html#undefined_), [`optional()`](/api.html#optional), [`nullable()`](/api.html#nullable), [`nullish()`](/api.html#nullish), [`unknown`](/api.html#unknown), [`maybe()`](/api.html#maybe), [`mixed`](/api.html#mixed)
 - [**Arrays**](#arrays): [`array()`](/api.html#array), [`nonEmptyArray()`](/api.html#nonEmptyArray), [`poja`](/api.html#poja), [`tuple()`](/api.html#tuple), [`set()`](/api.html#set)
-- [**Objects**](#objects): [`object()`](/api.html#object), [`exact()`](/api.html#exact), [`inexact()`](/api.html#inexact), [`pojo`](/api.html#pojo), [`record()`](/api.html#record), [`mapping()`](/api.html#mapping), [`dict()`](/api.html#dict)
+- [**Objects**](#objects): [`object()`](/api.html#object), [`exact()`](/api.html#exact), [`inexact()`](/api.html#inexact), [`pojo`](/api.html#pojo), [`record()`](/api.html#record), [`dict()`](/api.html#dict), [`mapping()`](/api.html#mapping)
 - [**JSON values**](#json-values): [`json`](/api.html#json), [`jsonObject`](/api.html#jsonObject), [`jsonArray`](/api.html#jsonArray)
 - [**Unions**](#unions): [`either()`](/api.html#either), [`oneOf()`](/api.html#oneOf), [`enum_()`](/api.html#enum_), [`taggedUnion()`](/api.html#taggedUnion), [`select()`](/api.html#select)
 - [**Utilities**](#utilities): [`define()`](/api.html#define), [`prep()`](/api.html#prep), [`never`](/api.html#never), [`instanceOf()`](/api.html#instanceOf), [`lazy()`](/api.html#lazy), [`fail`](/api.html#fail)
-<!--[[[end]]] (checksum: c22334a293d754403423358fc88159bb) -->
+<!--[[[end]]] (checksum: c0be8a7e7dcec98c939db298da5ce37c) -->
 
 <!--[[[cog
 for section, names in DECODERS_BY_SECTION.items():
@@ -959,8 +959,8 @@ decoder.verify([1, 2]);         // throws, not the right types
 - [`inexact()`](/api.html#inexact)
 - [`pojo`](/api.html#pojo)
 - [`record()`](/api.html#record)
+- [`dict()`](/api.html#dict)
 - [`mapping()`](/api.html#mapping)
-- [`dict()`](/api.html#dict) (alias of [`record()`](/api.html#record))
 
 ---
 
@@ -1056,31 +1056,65 @@ pojo.verify(null);        // throws
 
 ---
 
-<a href="#record">#</a> **record**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L259 'Source')
+<a href="#record">#</a> **record**&lt;<i style="color: #267f99">V</i>&gt;(values: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Record&lt;string, V&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L258 'Source')
 {: #record .signature}
 
-<a href="#dict">#</a> **dict**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L261-L265 'Source')
-{: #dict .signature}
+<a href="#record">#</a> **record**&lt;<i style="color: #267f99">K</i>, <i style="color: #267f99">V</i>&gt;(keys: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;K&gt;</i>, values: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Record&lt;K, V&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L258 'Source')
+{: #record .signature}
 
 Accepts objects where all values match the given decoder, and returns the
-result as a `Record<string, T>`.
+result as a `Record<string, V>`.
 
-The main difference between [`object()`](/api.html#object) and [`record()`](/api.html#record) is that you'd
-typically use [`object()`](/api.html#object) if this is a record-like object, where all field
-names are known and the values are heterogeneous. Whereas with [`record()`](/api.html#record)
-the keys are typically dynamic and the values homogeneous, like in
-a dictionary, a lookup table, or a cache.
+This is useful to validate inputs like `{ [key: string]: V }`.
+
+#### Decoding values only
+
+The default call takes a single argument and will validate all _values_.
+For example, to validate that all values in the object are numbers:
 
 ```ts
 const decoder = record(number);
+//                        \ 
+//                      Values must be numbers
 
 // 👍
-decoder.verify({ red: 1, blue: 2, green: 3 }); // ≈ { red: 1, blue: 2, green: 3 }
+decoder.verify({ red: 1, blue: 2, green: 3 });
+
+// 👎
+decoder.verify({ hi: 'not a number' });
+```
+
+#### Decoding keys and values
+
+If you also want to validate that keys are of a specific form, use the
+two-argument form: `record(key, value)`. Note that the given key decoder
+must return strings.
+
+For example, to enforce that all keys are emails:
+
+```ts
+const decoder = record(email, number);
+//                      /        \ 
+//              Keys must        Values must
+//             be emails           be numbers
+
+// 👍
+decoder.verify({ "me@nvie.com": 1 });
+
+// 👎
+decoder.verify({ "no-email": 1 });
 ```
 
 ---
 
-<a href="#mapping">#</a> **mapping**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Map&lt;string, T&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L267-L274 'Source')
+<a href="#dict">#</a> **dict**&lt;<i style="color: #267f99">V</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Record&lt;string, V&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L260-L264 'Source')
+{: #dict .signature}
+
+Alias of [`record()`](/api.html#record).
+
+---
+
+<a href="#mapping">#</a> **mapping**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Map&lt;string, T&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L266-L273 'Source')
 {: #mapping .signature}
 
 Similar to [`record()`](/api.html#record), but returns the result as a `Map<string, T>` (an [ES6
@@ -1516,5 +1550,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: d29cfb30cb5967a950acf0fa6ee6b82e)-->
+<!--[[[end]]] (checksum: a9678e5481bff7a7c38fc2875fc19d1f)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -1056,10 +1056,10 @@ pojo.verify(null);        // throws
 
 ---
 
-<a href="#record">#</a> **record**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L244 'Source')
+<a href="#record">#</a> **record**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L259 'Source')
 {: #record .signature}
 
-<a href="#dict">#</a> **dict**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L246-L250 'Source')
+<a href="#dict">#</a> **dict**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L261-L265 'Source')
 {: #dict .signature}
 
 Accepts objects where all values match the given decoder, and returns the
@@ -1080,7 +1080,7 @@ decoder.verify({ red: 1, blue: 2, green: 3 }); // ≈ { red: 1, blue: 2, green: 
 
 ---
 
-<a href="#mapping">#</a> **mapping**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Map&lt;string, T&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L252-L259 'Source')
+<a href="#mapping">#</a> **mapping**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Map&lt;string, T&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L267-L274 'Source')
 {: #mapping .signature}
 
 Similar to [`record()`](/api.html#record), but returns the result as a `Map<string, T>` (an [ES6
@@ -1516,5 +1516,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 99a8cdc97967332c081eb24425289e07)-->
+<!--[[[end]]] (checksum: d29cfb30cb5967a950acf0fa6ee6b82e)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,11 +35,11 @@ for section, names in DECODERS_BY_SECTION.items():
 - [**Constants**](#constants): [`constant()`](/api.html#constant), [`always()`](/api.html#always), [`hardcoded()`](/api.html#hardcoded)
 - [**Optionality**](#optionality): [`null_`](/api.html#null_), [`undefined_`](/api.html#undefined_), [`optional()`](/api.html#optional), [`nullable()`](/api.html#nullable), [`nullish()`](/api.html#nullish), [`unknown`](/api.html#unknown), [`maybe()`](/api.html#maybe), [`mixed`](/api.html#mixed)
 - [**Arrays**](#arrays): [`array()`](/api.html#array), [`nonEmptyArray()`](/api.html#nonEmptyArray), [`poja`](/api.html#poja), [`tuple()`](/api.html#tuple), [`set()`](/api.html#set)
-- [**Objects**](#objects): [`object()`](/api.html#object), [`exact()`](/api.html#exact), [`inexact()`](/api.html#inexact), [`pojo`](/api.html#pojo), [`dict()`](/api.html#dict), [`mapping()`](/api.html#mapping)
+- [**Objects**](#objects): [`object()`](/api.html#object), [`exact()`](/api.html#exact), [`inexact()`](/api.html#inexact), [`pojo`](/api.html#pojo), [`record()`](/api.html#record), [`mapping()`](/api.html#mapping), [`dict()`](/api.html#dict)
 - [**JSON values**](#json-values): [`json`](/api.html#json), [`jsonObject`](/api.html#jsonObject), [`jsonArray`](/api.html#jsonArray)
 - [**Unions**](#unions): [`either()`](/api.html#either), [`oneOf()`](/api.html#oneOf), [`enum_()`](/api.html#enum_), [`taggedUnion()`](/api.html#taggedUnion), [`select()`](/api.html#select)
 - [**Utilities**](#utilities): [`define()`](/api.html#define), [`prep()`](/api.html#prep), [`never`](/api.html#never), [`instanceOf()`](/api.html#instanceOf), [`lazy()`](/api.html#lazy), [`fail`](/api.html#fail)
-<!--[[[end]]] (checksum: 4623c37c1951846290664e89d0c8120a) -->
+<!--[[[end]]] (checksum: c22334a293d754403423358fc88159bb) -->
 
 <!--[[[cog
 for section, names in DECODERS_BY_SECTION.items():
@@ -958,8 +958,9 @@ decoder.verify([1, 2]);         // throws, not the right types
 - [`exact()`](/api.html#exact)
 - [`inexact()`](/api.html#inexact)
 - [`pojo`](/api.html#pojo)
-- [`dict()`](/api.html#dict)
+- [`record()`](/api.html#record)
 - [`mapping()`](/api.html#mapping)
+- [`dict()`](/api.html#dict) (alias of [`record()`](/api.html#record))
 
 ---
 
@@ -1055,20 +1056,23 @@ pojo.verify(null);        // throws
 
 ---
 
-<a href="#dict">#</a> **dict**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L244 'Source')
+<a href="#record">#</a> **record**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L207-L244 'Source')
+{: #record .signature}
+
+<a href="#dict">#</a> **dict**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;{ [key: string]: T }&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L246-L250 'Source')
 {: #dict .signature}
 
 Accepts objects where all values match the given decoder, and returns the
 result as a `Record<string, T>`.
 
-The main difference between [`object()`](/api.html#object) and [`dict()`](/api.html#dict) is that you'd typically
-use [`object()`](/api.html#object) if this is a record-like object, where all field names are
-known and the values are heterogeneous. Whereas with [`dict()`](/api.html#dict) the keys are
-typically dynamic and the values homogeneous, like in a dictionary,
-a lookup table, or a cache.
+The main difference between [`object()`](/api.html#object) and [`record()`](/api.html#record) is that you'd
+typically use [`object()`](/api.html#object) if this is a record-like object, where all field
+names are known and the values are heterogeneous. Whereas with [`record()`](/api.html#record)
+the keys are typically dynamic and the values homogeneous, like in
+a dictionary, a lookup table, or a cache.
 
 ```ts
-const decoder = dict(number);
+const decoder = record(number);
 
 // 👍
 decoder.verify({ red: 1, blue: 2, green: 3 }); // ≈ { red: 1, blue: 2, green: 3 }
@@ -1076,10 +1080,10 @@ decoder.verify({ red: 1, blue: 2, green: 3 }); // ≈ { red: 1, blue: 2, green: 
 
 ---
 
-<a href="#mapping">#</a> **mapping**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Map&lt;string, T&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L246-L260 'Source')
+<a href="#mapping">#</a> **mapping**&lt;<i style="color: #267f99">T</i>&gt;(decoder: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;Map&lt;string, T&gt;&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/objects.ts#L252-L259 'Source')
 {: #mapping .signature}
 
-Similar to [`dict()`](/api.html#dict), but returns the result as a `Map<string, T>` (an [ES6
+Similar to [`record()`](/api.html#record), but returns the result as a `Map<string, T>` (an [ES6
 Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map))
 instead.
 
@@ -1512,5 +1516,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 2b713ba4b32a533c8c8c2f7018d808db)-->
+<!--[[[end]]] (checksum: 99a8cdc97967332c081eb24425289e07)-->
 <!-- prettier-ignore-end -->

--- a/src/basics.ts
+++ b/src/basics.ts
@@ -63,7 +63,7 @@ export function nullable<T, V>(
 
 /**
  * @deprecated
- * Alias of nullish().
+ * Alias of `nullish()`.
  */
 export const maybe = nullish;
 
@@ -124,13 +124,13 @@ export function never(msg: string): Decoder<never> {
 }
 
 /**
- * Alias of never().
+ * Alias of `never()`.
  */
 export const fail = never;
 
 /**
  * @deprecated
- * Alias of always.
+ * Alias of `always()`.
  */
 export const hardcoded = always;
 
@@ -145,6 +145,6 @@ export const unknown: Decoder<unknown> = define((blob, ok, _) => ok(blob));
 
 /**
  * @deprecated
- * Alias of unknown.
+ * Alias of `unknown`.
  */
 export const mixed = unknown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export { json, jsonArray, jsonObject } from './json';
 export { instanceOf, lazy, prep } from './misc';
 export { anyNumber, integer, number, positiveInteger, positiveNumber } from './numbers';
 export { bigint } from './numbers';
-export { dict, exact, inexact, mapping, object, pojo } from './objects';
+export { dict, exact, inexact, mapping, object, pojo, record } from './objects';
 export { nonEmptyString, regex, string } from './strings';
 export { email, httpsUrl, url, uuid, uuidv1, uuidv4 } from './strings';
 export { decimal, hexadecimal, numeric } from './strings';

--- a/src/json.ts
+++ b/src/json.ts
@@ -5,7 +5,7 @@ import { null_ } from './basics';
 import { boolean } from './booleans';
 import { lazy } from './misc';
 import { number } from './numbers';
-import { dict } from './objects';
+import { record } from './objects';
 import { string } from './strings';
 import { either } from './unions';
 
@@ -16,7 +16,7 @@ export type JSONArray = JSONValue[];
 /**
  * Accepts objects that contain only valid JSON values.
  */
-export const jsonObject: Decoder<JSONObject> = lazy(() => dict(json));
+export const jsonObject: Decoder<JSONObject> = lazy(() => record(json));
 
 /**
  * Accepts arrays that contain only valid JSON values.

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -208,13 +208,13 @@ export function inexact<Ds extends Record<string, Decoder<unknown>>>(
  * Accepts objects where all values match the given decoder, and returns the
  * result as a `Record<string, T>`.
  *
- * The main difference between `object()` and `dict()` is that you'd typically
- * use `object()` if this is a record-like object, where all field names are
- * known and the values are heterogeneous. Whereas with `dict()` the keys are
- * typically dynamic and the values homogeneous, like in a dictionary,
- * a lookup table, or a cache.
+ * The main difference between `object()` and `record()` is that you'd
+ * typically use `object()` if this is a record-like object, where all field
+ * names are known and the values are heterogeneous. Whereas with `record()`
+ * the keys are typically dynamic and the values homogeneous, like in
+ * a dictionary, a lookup table, or a cache.
  */
-export function dict<T>(decoder: Decoder<T>): Decoder<Record<string, T>> {
+export function record<T>(decoder: Decoder<T>): Decoder<Record<string, T>> {
   return pojo.then((plainObj, ok, err) => {
     let rv: Record<string, T> = {};
     let errors: Map<string, Annotation> | null = null;
@@ -244,17 +244,16 @@ export function dict<T>(decoder: Decoder<T>): Decoder<Record<string, T>> {
 }
 
 /**
- * Similar to `dict()`, but returns the result as a `Map<string, T>` (an [ES6
+ * @deprecated
+ * Alias of record().
+ */
+export const dict = record;
+
+/**
+ * Similar to `record()`, but returns the result as a `Map<string, T>` (an [ES6
  * Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map))
  * instead.
  */
 export function mapping<T>(decoder: Decoder<T>): Decoder<Map<string, T>> {
-  return dict(decoder).transform(
-    (obj) =>
-      new Map(
-        // This is effectively Object.entries(obj), but in a way that Flow
-        // will know the types are okay
-        Object.keys(obj).map((key) => [key, obj[key]]),
-      ),
-  );
+  return record(decoder).transform((obj) => new Map(Object.entries(obj)));
 }

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -206,22 +206,21 @@ export function inexact<Ds extends Record<string, Decoder<unknown>>>(
 
 /**
  * Accepts objects where all values match the given decoder, and returns the
- * result as a `Record<string, T>`.
- *
- * The main difference between `object()` and `record()` is that you'd
- * typically use `object()` if this is a record-like object, where all field
- * names are known and the values are heterogeneous. Whereas with `record()`
- * the keys are typically dynamic and the values homogeneous, like in
- * a dictionary, a lookup table, or a cache.
+ * result as a `Record<string, V>`.
  */
 export function record<V>(valueDecoder: Decoder<V>): Decoder<Record<string, V>>;
-export function record<K extends string, V>( keyDecoder: Decoder<K>, valueDecoder: Decoder<V>): Decoder<Record<K, V>>; // prettier-ignore
+/**
+ * Accepts objects where all keys and values match the given decoders, and
+ * returns the result as a `Record<K, V>`. The given key decoder must return
+ * strings.
+ */
+export function record<K extends string, V>(keyDecoder: Decoder<K>, valueDecoder: Decoder<V>): Decoder<Record<K, V>>; // prettier-ignore
 export function record<K extends string, V>(
-  fst: Decoder<unknown>,
-  snd?: Decoder<unknown>,
+  fst: Decoder<K> | Decoder<V>,
+  snd?: Decoder<V>,
 ): Decoder<Record<K, V>> {
   const keyDecoder = snd !== undefined ? (fst as Decoder<K>) : undefined;
-  const valueDecoder = snd !== undefined ? (snd as Decoder<V>) : (fst as Decoder<V>);
+  const valueDecoder = snd !== undefined ? snd : (fst as Decoder<V>);
   return pojo.then((rec, ok, err) => {
     let rv = {} as Record<K, V>;
     const errors: Map<string, Annotation> = new Map();

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -214,14 +214,13 @@ export function inexact<Ds extends Record<string, Decoder<unknown>>>(
  * the keys are typically dynamic and the values homogeneous, like in
  * a dictionary, a lookup table, or a cache.
  */
-export function record<T>(decoder: Decoder<T>): Decoder<Record<string, T>> {
-  return pojo.then((plainObj, ok, err) => {
-    let rv: Record<string, T> = {};
+export function record<V>(valueDecoder: Decoder<V>): Decoder<Record<string, V>> {
+  return pojo.then((rec, ok, err) => {
+    let rv: Record<string, V> = {};
     let errors: Map<string, Annotation> | null = null;
 
-    for (const key of Object.keys(plainObj)) {
-      const value = plainObj[key];
-      const result = decoder.decode(value);
+    for (const [key, value] of Object.entries(rec)) {
+      const result = valueDecoder.decode(value);
       if (result.ok) {
         if (errors === null) {
           rv[key] = result.value;
@@ -236,7 +235,7 @@ export function record<T>(decoder: Decoder<T>): Decoder<Record<string, T>> {
     }
 
     if (errors !== null) {
-      return err(merge(annotateObject(plainObj), errors));
+      return err(merge(annotateObject(rec), errors));
     } else {
       return ok(rv);
     }

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { Annotation, Decoder, DecodeResult, DecoderType } from '~/core';
-import { annotateObject, define, merge, updateText } from '~/core';
+import { annotate, annotateObject, define, formatShort, merge, updateText } from '~/core';
 import { difference } from '~/lib/set-methods';
 import { isPojo } from '~/lib/utils';
 
@@ -214,27 +214,43 @@ export function inexact<Ds extends Record<string, Decoder<unknown>>>(
  * the keys are typically dynamic and the values homogeneous, like in
  * a dictionary, a lookup table, or a cache.
  */
-export function record<V>(valueDecoder: Decoder<V>): Decoder<Record<string, V>> {
+export function record<V>(valueDecoder: Decoder<V>): Decoder<Record<string, V>>;
+export function record<K extends string, V>( keyDecoder: Decoder<K>, valueDecoder: Decoder<V>): Decoder<Record<K, V>>; // prettier-ignore
+export function record<K extends string, V>(
+  fst: Decoder<unknown>,
+  snd?: Decoder<unknown>,
+): Decoder<Record<K, V>> {
+  const keyDecoder = snd !== undefined ? (fst as Decoder<K>) : undefined;
+  const valueDecoder = snd !== undefined ? (snd as Decoder<V>) : (fst as Decoder<V>);
   return pojo.then((rec, ok, err) => {
-    let rv: Record<string, V> = {};
-    let errors: Map<string, Annotation> | null = null;
+    let rv = {} as Record<K, V>;
+    const errors: Map<string, Annotation> = new Map();
 
     for (const [key, value] of Object.entries(rec)) {
+      const keyResult = keyDecoder?.decode(key);
+      if (keyResult?.ok === false) {
+        return err(
+          annotate(
+            rec,
+            `Invalid key ${JSON.stringify(key)}: ${formatShort(keyResult.error)}`,
+          ),
+        );
+      }
+
+      const k = keyResult?.value ?? (key as K);
+
       const result = valueDecoder.decode(value);
       if (result.ok) {
-        if (errors === null) {
-          rv[key] = result.value;
+        if (errors.size === 0) {
+          rv[k] = result.value;
         }
       } else {
-        rv = {}; // Clear the success value so it can get garbage collected early
-        if (errors === null) {
-          errors = new Map();
-        }
         errors.set(key, result.error);
+        rv = {} as Record<K, V>; // Clear the success value so it can get garbage collected early
       }
     }
 
-    if (errors !== null) {
+    if (errors.size > 0) {
       return err(merge(annotateObject(rec), errors));
     } else {
       return ok(rv);
@@ -244,7 +260,7 @@ export function record<V>(valueDecoder: Decoder<V>): Decoder<Record<string, V>> 
 
 /**
  * @deprecated
- * Alias of record().
+ * Alias of `record()`.
  */
 export const dict = record;
 

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -320,6 +320,9 @@ expectType<unknown>(test(inexact({})).b);
 expectType<Record<string, unknown>>(test(pojo));
 expectType<Map<string, number>>(test(mapping(number)));
 expectType<Record<string, number>>(test(record(number)));
+expectType<Record<'foo' | 'bar', number>>(
+  test(record(oneOf(['foo', 'bar'] as const), number)),
+);
 expectType<Record<string, number>>(test(dict(number)));
 
 expectType<string>(test(lazy(() => string)));

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -232,7 +232,7 @@ expectType<string | Date | null | undefined>(
   test(nullish(nullish(string, () => new Date()))),
 );
 
-// Alias of nullish
+// Alias of `nullish()`
 expectType<string | null | undefined>(test(maybe(string)));
 expectType<string | null | undefined>(test(maybe(maybe(string))));
 expectType<string | 42>(test(maybe(string, 42)));

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -46,6 +46,7 @@ import {
   positiveInteger,
   positiveNumber,
   prep,
+  record,
   regex,
   select,
   set,
@@ -318,6 +319,7 @@ expectType<unknown>(test(inexact({})).b);
 
 expectType<Record<string, unknown>>(test(pojo));
 expectType<Map<string, number>>(test(mapping(number)));
+expectType<Record<string, number>>(test(record(number)));
 expectType<Record<string, number>>(test(dict(number)));
 
 expectType<string>(test(lazy(() => string)));

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -319,11 +319,26 @@ expectType<unknown>(test(inexact({})).b);
 
 expectType<Record<string, unknown>>(test(pojo));
 expectType<Map<string, number>>(test(mapping(number)));
+
+// Single-argument form (validate values only)
 expectType<Record<string, number>>(test(record(number)));
+
+// Two-argument form (validate keys and values)
 expectType<Record<'foo' | 'bar', number>>(
   test(record(oneOf(['foo', 'bar'] as const), number)),
 );
+expectType<Record<string, number>>(test(record(decimal, number)));
+expectType<Record<string, boolean>>(test(record(email, boolean)));
+
+// Single-argument form (validate values only)
 expectType<Record<string, number>>(test(dict(number)));
+
+// Two-argument form (validate keys and values)
+expectType<Record<'foo' | 'bar', number>>(
+  test(dict(oneOf(['foo', 'bar'] as const), number)),
+);
+expectType<Record<string, number>>(test(dict(decimal, number)));
+expectType<Record<string, boolean>>(test(dict(email, boolean)));
 
 expectType<string>(test(lazy(() => string)));
 expectType<number>(test(lazy(() => number)));

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import { hardcoded, optional, unknown } from '~/basics';
 import { number } from '~/numbers';
-import { dict, exact, inexact, mapping, object, pojo } from '~/objects';
+import { record, exact, inexact, mapping, object, pojo } from '~/objects';
 import { string } from '~/strings';
 
 describe('objects', () => {
@@ -422,8 +422,8 @@ describe('mapping', () => {
   });
 });
 
-describe('dict', () => {
-  const decoder = dict(object({ name: string }));
+describe('record', () => {
+  const decoder = record(object({ name: string }));
 
   test('valid', () => {
     const input = {


### PR DESCRIPTION
#### Decoding values only

The default call takes a single argument and will validate all _values_. For example, to validate that all values in the object are numbers:

```ts
const decoder = record(number);
//                        \ 
//                      Values must be numbers

// 👍
decoder.verify({ red: 1, blue: 2, green: 3 });

// 👎
decoder.verify({ hi: 'not a number' });
```

#### Decoding keys and values

If you also want to validate that keys are of a specific form, use the two-argument form: `record(key, value)`. Note that the given key decoder must return strings.

For example, to enforce that all keys are emails:

```ts
const decoder = record(email, number);
//                      /        \ 
//              Keys must        Values must
//             be emails           be numbers

// 👍
decoder.verify({ "me@nvie.com": 1 });

// 👎
decoder.verify({ "no-email": 1 });
```
