### PR TITLE
Add `.pipe()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Make `.then()` multi-functional. Previously, it took an "acceptance function", but its
   argument can now also be, or return, a `Decoder<V>`. This makes piping a lot easier in
   practice.
+- A new `.pipe()` operation on Decoder. Using `first.pipe(second)` is now technically
+  equivalent to `first.then(second)` (because of the point above), but its type is more
+  ergonomic and clear.
 - The `formatShort` formatter will now quote error positions with single quotes, which
   makes them more human-readable in JSON responses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 **New features:**
 
+- Make `.then()` multi-functional. Previously, it took an "acceptance function", but its
+  argument can now also be, or return, a `Decoder<V>`. This makes piping a lot easier in
+  practice.
 - The `formatShort` formatter will now quote error positions with single quotes, which
   makes them more human-readable in JSON responses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,26 @@
 
 **New features:**
 
-- Make `.then()` multi-functional. Previously, it took an "acceptance function", but its
-  argument can now also be, or return, a `Decoder<V>`. This makes piping a lot easier in
-  practice.
-- A new `.pipe()` operation on Decoder. Using `first.pipe(second)` is now technically
-  equivalent to `first.then(second)` (because of the point above), but its type is more
-  ergonomic and clear.
+- A new `.pipe()` method on Decoder allows you to pass the output of one decoder as input
+  to another:
+  ```tsx
+  string
+    .transform((s) => s.split(',')) // transform first...
+    .pipe(array(nonEmptyString)); //   ...then validate that result
+  ```
+  This was previously possible already with `.then`, but it was hard to work with.
+- The new `.pipe()` can also dynamically select another decoder, based on the input:
+  ```tsx
+  string
+    .transform((s) => s.split(',').map(Number)) // transform first...
+    .pipe((tup) =>
+      tup.length === 2
+        ? point2d
+        : tup.length === 3
+          ? point3d
+          : never('Invalid coordinate'),
+    );
+  ```
 - The `formatShort` formatter will now quote error positions with single quotes, which
   makes them more human-readable in JSON responses.
 

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -45,7 +45,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L183-L195 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L181-L193 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -70,7 +70,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L197-L207 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L195-L205 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -96,7 +96,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L171-L181 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L169-L179 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -118,7 +118,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L209-L217 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L207-L215 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -138,7 +138,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L219-L232 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L217-L230 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -163,7 +163,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L279-L297 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L274-L292 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -196,7 +196,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L299-L316 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L294-L311 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -208,65 +208,59 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L234-L253 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L232-L250 'Source')
 {: #then .signature}
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L234-L253 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L232-L250 'Source')
 {: #then .signature}
 
-XXX Double-check these docs!
-XXX Keep these docs in sync!
 Send the output of the current decoder into another decoder or acceptance
 function. The given acceptance function will receive the output of the
-current decoder as its input, making it partially trusted.
+current decoder as its input.
 
 > _**NOTE:** This is an advanced, low-level, API. It's not recommended
 > to reach for this construct unless there is no other way. Most cases can
-> be covered more elegantly by [`.transform()`](/Decoder.html#transform) or [`.refine()`](/Decoder.html#refine) instead._
+> be covered more elegantly by [`.transform()`](/Decoder.html#transform), [`.refine()`](/Decoder.html#refine), or [`.pipe()`](/Decoder.html#pipe)
+> instead._
 
 ---
 
-<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L255-L277 'Source')
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L252-L272 'Source')
 {: #pipe .signature}
 
-<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L255-L277 'Source')
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L252-L272 'Source')
 {: #pipe .signature}
 
-XXX Double-check these docs!
-XXX Keep these docs in sync!
-Send the output of the current decoder to another decoder.
+Send the output of this decoder as input to another decoder.
 
-This can be useful to validate the results of a previous transform, so in
-a typical example, you do something like this:
+This can be useful to validate the results of a transform, i.e.:
 
   string
-    .transform(s => Number(s))
-    .pipe(positiveInteger)
+    .transform((s) => s.split(','))
+    .pipe(array(nonEmptyString))
 
-Note that the given decoder does not know anything about the given
-returned value. In the example above, for example, TypeScript knows that
-the input to the [`positiveInteger`](/api.html#positiveInteger) decoder will be of type [`number`](/api.html#number), but
-to the [`positiveInteger`](/api.html#positiveInteger) its input is completely opaque.
+You can also conditionally pipe:
+
+  string.pipe((s) => s.startsWith('@') ? username : email)
 
 ```ts
-// XXX Double-check if this is the best example
 const decoder =
   string
-    .transform(s => Number(s))
-    .pipe(positiveInteger);
+    .transform((s) => s.split(',').map(Number))
+    .pipe(array(positiveInteger));
 
 // 👍
-decoder.verify('7') === 7;
-decoder.verify('123') === 123;
+decoder.verify('7') === [7];
+decoder.verify('1,2,3') === [1, 2, 3];
 
 // 👎
+decoder.verify('1,-3')  // -3 is not positive
 decoder.verify('🚀');   // not a number
 decoder.verify('3.14'); // not a whole number
-decoder.verify('-3');   // not a positive number
 decoder.verify(123);    // not a string
 decoder.verify(true);   // not a string
 decoder.verify(null);   // not a string
 ```
 
-<!--[[[end]]] (checksum: 5a5411b67804cb8cbf8836894f73f2e5) -->
+<!--[[[end]]] (checksum: 2deee52ed374299960eadd32fa2b3797) -->
 <!-- prettier-ignore-end -->

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -44,7 +44,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L160-L172 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L173-L185 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -69,7 +69,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L174-L184 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L187-L197 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -95,7 +95,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L148-L158 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L161-L171 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -117,7 +117,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L186-L194 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L199-L207 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -137,7 +137,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L196-L209 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L209-L222 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -162,7 +162,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L237-L255 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L262-L280 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -195,7 +195,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L257-L274 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L282-L299 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -207,7 +207,7 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L211-L235 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L224-L260 'Source')
 {: #then .signature}
 
 Chain together the current decoder with another.
@@ -228,5 +228,5 @@ about its input and avoid re-refining inputs.
 If it helps, you can think of `define(...)` as equivalent to
 `unknown.then(...)`.
 
-<!--[[[end]]] (checksum: 291a1600755cc7b28b42fc11c7638e9a) -->
+<!--[[[end]]] (checksum: 52f837d84400dac8d811836cfc0758ff) -->
 <!-- prettier-ignore-end -->

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -45,7 +45,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L175-L187 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L183-L195 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -70,7 +70,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L189-L199 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L197-L207 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -96,7 +96,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L162-L173 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L171-L181 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -118,7 +118,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L201-L209 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L209-L217 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -138,7 +138,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L211-L224 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L219-L232 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -163,7 +163,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L267-L285 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L279-L297 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -196,7 +196,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L287-L304 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L299-L316 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -208,9 +208,14 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L226-L243 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L234-L253 'Source')
 {: #then .signature}
 
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L234-L253 'Source')
+{: #then .signature}
+
+XXX Double-check these docs!
+XXX Keep these docs in sync!
 Send the output of the current decoder into another decoder or acceptance
 function. The given acceptance function will receive the output of the
 current decoder as its input, making it partially trusted.
@@ -221,9 +226,14 @@ current decoder as its input, making it partially trusted.
 
 ---
 
-<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L245-L265 'Source')
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L255-L277 'Source')
 {: #pipe .signature}
 
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L255-L277 'Source')
+{: #pipe .signature}
+
+XXX Double-check these docs!
+XXX Keep these docs in sync!
 Send the output of the current decoder to another decoder.
 
 This can be useful to validate the results of a previous transform, so in
@@ -238,5 +248,25 @@ returned value. In the example above, for example, TypeScript knows that
 the input to the [`positiveInteger`](/api.html#positiveInteger) decoder will be of type [`number`](/api.html#number), but
 to the [`positiveInteger`](/api.html#positiveInteger) its input is completely opaque.
 
-<!--[[[end]]] (checksum: 99b0ff6dfdc15f440d75766ba6605d43) -->
+```ts
+// XXX Double-check if this is the best example
+const decoder =
+  string
+    .transform(s => Number(s))
+    .pipe(positiveInteger);
+
+// 👍
+decoder.verify('7') === 7;
+decoder.verify('123') === 123;
+
+// 👎
+decoder.verify('🚀');   // not a number
+decoder.verify('3.14'); // not a whole number
+decoder.verify('-3');   // not a positive number
+decoder.verify(123);    // not a string
+decoder.verify(true);   // not a string
+decoder.verify(null);   // not a string
+```
+
+<!--[[[end]]] (checksum: 5a5411b67804cb8cbf8836894f73f2e5) -->
 <!-- prettier-ignore-end -->

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -45,7 +45,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L181-L193 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L173-L185 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -70,7 +70,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L195-L205 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L187-L197 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -96,7 +96,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L169-L179 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L161-L171 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -118,7 +118,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L207-L215 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L199-L207 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -138,7 +138,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L217-L230 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L209-L222 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -163,7 +163,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L274-L292 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L266-L284 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -196,7 +196,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L294-L311 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L286-L303 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -208,10 +208,10 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L232-L250 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt; | <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L224-L242 'Source')
 {: #then .signature}
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L232-L250 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L224-L242 'Source')
 {: #then .signature}
 
 Send the output of the current decoder into another decoder or acceptance
@@ -225,10 +225,10 @@ current decoder as its input.
 
 ---
 
-<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L252-L272 'Source')
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L244-L264 'Source')
 {: #pipe .signature}
 
-<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L252-L272 'Source')
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L244-L264 'Source')
 {: #pipe .signature}
 
 ```tsx
@@ -266,5 +266,5 @@ string
   );
 ```
 
-<!--[[[end]]] (checksum: 4f942dcffed13c1c0521ed0a080087b4) -->
+<!--[[[end]]] (checksum: a87184fec5d1484dd8db645269a5a972) -->
 <!-- prettier-ignore-end -->

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -231,19 +231,7 @@ current decoder as its input.
 <a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T) =&gt; <a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L252-L272 'Source')
 {: #pipe .signature}
 
-Send the output of this decoder as input to another decoder.
-
-This can be useful to validate the results of a transform, i.e.:
-
-  string
-    .transform((s) => s.split(','))
-    .pipe(array(nonEmptyString))
-
-You can also conditionally pipe:
-
-  string.pipe((s) => s.startsWith('@') ? username : email)
-
-```ts
+```tsx
 const decoder =
   string
     .transform((s) => s.split(',').map(Number))
@@ -262,5 +250,21 @@ decoder.verify(true);   // not a string
 decoder.verify(null);   // not a string
 ```
 
-<!--[[[end]]] (checksum: 2deee52ed374299960eadd32fa2b3797) -->
+#### Dynamic decoder selection with ``.pipe()``
+
+With [`.pipe()`](/Decoder.html#pipe) you can also dynamically select another decoder, based on dynamic runtime value.
+
+```tsx
+string
+  .transform((s) => s.split(',').map(Number))
+  .pipe((tup) =>
+    tup.length === 2
+      ? point2d
+      : tup.length === 3
+        ? point3d
+        : never('Invalid coordinate'),
+  );
+```
+
+<!--[[[end]]] (checksum: 4f942dcffed13c1c0521ed0a080087b4) -->
 <!-- prettier-ignore-end -->

--- a/docs/Decoder.md
+++ b/docs/Decoder.md
@@ -31,7 +31,8 @@ for name in DECODER_METHODS:
 - [`.reject()`](/Decoder.html#reject)
 - [`.describe()`](/Decoder.html#describe)
 - [`.then()`](/Decoder.html#then)
-<!--[[[end]]] (checksum: 6a2e8a4534ef2323c6a0c62eac2fed90) -->
+- [`.pipe()`](/Decoder.html#pipe)
+<!--[[[end]]] (checksum: 076ce6c004cb18a363b0b57b48ecaa60) -->
 
 <!--[[[cog
 for name in DECODER_METHODS:
@@ -44,7 +45,7 @@ for name in DECODER_METHODS:
 ]]]-->
 ---
 
-<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L173-L185 'Source')
+<a href="#verify">#</a> **.verify**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L175-L187 'Source')
 {: #verify .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -69,7 +70,7 @@ number.verify('hello'); // throws
 
 ---
 
-<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L187-L197 'Source')
+<a href="#value">#</a> **.value**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">T | undefined</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L189-L199 'Source')
 {: #value .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -95,7 +96,7 @@ string.value(42);    // undefined
 
 ---
 
-<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L161-L171 'Source')
+<a href="#decode">#</a> **.decode**(blob: <i style="color: #267f99">mixed</i>): <i style="color: #267f99">DecodeResult&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L162-L173 'Source')
 {: #decode .signature}
 
 Verifies the untrusted/unknown input and either accepts or rejects it.
@@ -117,7 +118,7 @@ number.decode('hi');  // { ok: false, error: { type: 'scalar', value: 'hi', text
 
 ---
 
-<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L199-L207 'Source')
+<a href="#transform">#</a> **.transform**&lt;<i style="color: #267f99">V</i>&gt;(transformFn: <i style="color: #267f99">(T) =&gt; V</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L201-L209 'Source')
 {: #transform .signature}
 
 Accepts any value the given decoder accepts, and on success, will call
@@ -137,7 +138,7 @@ upper.verify(4);  // throws
 
 ---
 
-<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L209-L222 'Source')
+<a href="#refine">#</a> **.refine**(predicate: <i style="color: #267f99">T =&gt; boolean</i>, message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L211-L224 'Source')
 {: #refine .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -162,7 +163,7 @@ In TypeScript, if you provide a predicate that also is a [type predicate](https:
 
 ---
 
-<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L262-L280 'Source')
+<a href="#reject">#</a> **.reject**(rejectFn: <i style="color: #267f99">T =&gt; string | null</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L267-L285 'Source')
 {: #reject .signature}
 
 Adds an extra predicate to a decoder. The new decoder is like the
@@ -195,7 +196,7 @@ decoder.verify({ id: 123, _name: 'Vincent'  })   // throws: "Disallowed keys: _n
 
 ---
 
-<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L282-L299 'Source')
+<a href="#describe">#</a> **.describe**(message: <i style="color: #267f99">string</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L287-L304 'Source')
 {: #describe .signature}
 
 Uses the given decoder, but will use an alternative error message in case it rejects. This can be used to simplify or shorten otherwise long or low-level/technical errors.
@@ -207,26 +208,35 @@ const vowel = oneOf(['a', 'e', 'i', 'o', 'u'])
 
 ---
 
-<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L224-L260 'Source')
+<a href="#then">#</a> **.then**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99">(blob: T, ok, err) =&gt; DecodeResult&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L226-L243 'Source')
 {: #then .signature}
 
-Chain together the current decoder with another.
+Send the output of the current decoder into another decoder or acceptance
+function. The given acceptance function will receive the output of the
+current decoder as its input, making it partially trusted.
 
 > _**NOTE:** This is an advanced, low-level, API. It's not recommended
 > to reach for this construct unless there is no other way. Most cases can
 > be covered more elegantly by [`.transform()`](/Decoder.html#transform) or [`.refine()`](/Decoder.html#refine) instead._
 
-If the current decoder accepts an input, the resulting ``T`` value will
-get passed into the given ``next`` acceptance function to further decide
-whether or not the value should get accepted or rejected.
+---
 
-This works similar to how you would [`define()`](/api.html#define) a new decoder, except
-that the ``blob`` param will now be ``T`` (a known type), rather than
-``unknown``. This will allow the function to make a stronger assumption
-about its input and avoid re-refining inputs.
+<a href="#pipe">#</a> **.pipe**&lt;<i style="color: #267f99">V</i>&gt;(next: <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;V&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L245-L265 'Source')
+{: #pipe .signature}
 
-If it helps, you can think of `define(...)` as equivalent to
-`unknown.then(...)`.
+Send the output of the current decoder to another decoder.
 
-<!--[[[end]]] (checksum: 52f837d84400dac8d811836cfc0758ff) -->
+This can be useful to validate the results of a previous transform, so in
+a typical example, you do something like this:
+
+  string
+    .transform(s => Number(s))
+    .pipe(positiveInteger)
+
+Note that the given decoder does not know anything about the given
+returned value. In the example above, for example, TypeScript knows that
+the input to the [`positiveInteger`](/api.html#positiveInteger) decoder will be of type [`number`](/api.html#number), but
+to the [`positiveInteger`](/api.html#positiveInteger) its input is completely opaque.
+
+<!--[[[end]]] (checksum: 99b0ff6dfdc15f440d75766ba6605d43) -->
 <!-- prettier-ignore-end -->

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -1464,23 +1464,64 @@ DECODER_METHODS = {
   },
 
   'then': {
-    'type_params': ['V'],
-    'params': [
-      ('next', '(blob: T, ok, err) => DecodeResult<V>'),
+    'signatures': [
+      {
+        'type_params': ['V'],
+        'params': [
+          ('next', '(blob: T, ok, err) => DecodeResult<V> | Decoder<V>'),
+        ],
+        'return_type': 'Decoder<V>',
+      },
+      {
+        'type_params': ['V'],
+        'params': [
+          ('next', 'Decoder<V>'),
+        ],
+        'return_type': 'Decoder<V>',
+        },
     ],
-    'return_type': 'Decoder<V>',
+
     # 'example': """
     # """,
   },
 
   'pipe': {
     'type_params': ['V'],
-    'params': [
-      ('next', 'Decoder<V>'),
+
+    'signatures': [
+      {
+        'type_params': ['V'],
+        'params': [('next', 'Decoder<V>')],
+        'return_type': 'Decoder<V>',
+      },
+      {
+        'type_params': ['V'],
+        'params': [
+          ('next', '(blob: T) => Decoder<V>'),
+        ],
+        'return_type': 'Decoder<V>',
+      },
     ],
-    'return_type': 'Decoder<V>',
-    # 'example': """
-    # """,
+
+    'example': """
+      // XXX Double-check if this is the best example
+      const decoder =
+        string
+          .transform(s => Number(s))
+          .pipe(positiveInteger);
+
+      // 👍
+      decoder.verify('7') === 7;
+      decoder.verify('123') === 123;
+
+      // 👎
+      decoder.verify('🚀');   // not a number
+      decoder.verify('3.14'); // not a whole number
+      decoder.verify('-3');   // not a positive number
+      decoder.verify(123);    // not a string
+      decoder.verify(true);   // not a string
+      decoder.verify(null);   // not a string
+    """,
   },
 }
 

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -1502,23 +1502,41 @@ DECODER_METHODS = {
       },
     ],
 
-    'example': """
-      const decoder =
-        string
-          .transform((s) => s.split(',').map(Number))
-          .pipe(array(positiveInteger));
+    'markdown': """
+    ```tsx
+    const decoder =
+      string
+        .transform((s) => s.split(',').map(Number))
+        .pipe(array(positiveInteger));
 
-      // 👍
-      decoder.verify('7') === [7];
-      decoder.verify('1,2,3') === [1, 2, 3];
+    // 👍
+    decoder.verify('7') === [7];
+    decoder.verify('1,2,3') === [1, 2, 3];
 
-      // 👎
-      decoder.verify('1,-3')  // -3 is not positive
-      decoder.verify('🚀');   // not a number
-      decoder.verify('3.14'); // not a whole number
-      decoder.verify(123);    // not a string
-      decoder.verify(true);   // not a string
-      decoder.verify(null);   // not a string
+    // 👎
+    decoder.verify('1,-3')  // -3 is not positive
+    decoder.verify('🚀');   // not a number
+    decoder.verify('3.14'); // not a whole number
+    decoder.verify(123);    // not a string
+    decoder.verify(true);   // not a string
+    decoder.verify(null);   // not a string
+    ```
+
+    #### Dynamic decoder selection with ``.pipe()``
+
+    With `.pipe()` you can also dynamically select another decoder, based on dynamic runtime value.
+
+    ```tsx
+    string
+      .transform((s) => s.split(',').map(Number))
+      .pipe((tup) =>
+        tup.length === 2
+          ? point2d
+          : tup.length === 3
+            ? point3d
+            : never('Invalid coordinate'),
+      );
+    ```
     """,
   },
 }

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -1472,6 +1472,16 @@ DECODER_METHODS = {
     # 'example': """
     # """,
   },
+
+  'pipe': {
+    'type_params': ['V'],
+    'params': [
+      ('next', 'Decoder<V>'),
+    ],
+    'return_type': 'Decoder<V>',
+    # 'example': """
+    # """,
+  },
 }
 
 

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -1480,7 +1480,6 @@ DECODER_METHODS = {
         'return_type': 'Decoder<V>',
         },
     ],
-
     # 'example': """
     # """,
   },
@@ -1504,20 +1503,19 @@ DECODER_METHODS = {
     ],
 
     'example': """
-      // XXX Double-check if this is the best example
       const decoder =
         string
-          .transform(s => Number(s))
-          .pipe(positiveInteger);
+          .transform((s) => s.split(',').map(Number))
+          .pipe(array(positiveInteger));
 
       // 👍
-      decoder.verify('7') === 7;
-      decoder.verify('123') === 123;
+      decoder.verify('7') === [7];
+      decoder.verify('1,2,3') === [1, 2, 3];
 
       // 👎
+      decoder.verify('1,-3')  // -3 is not positive
       decoder.verify('🚀');   // not a number
       decoder.verify('3.14'); // not a whole number
-      decoder.verify('-3');   // not a positive number
       decoder.verify(123);    // not a string
       decoder.verify(true);   // not a string
       decoder.verify(null);   // not a string

--- a/docs/api.md
+++ b/docs/api.md
@@ -1494,7 +1494,7 @@ const decoder = select(
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L157-L348 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L155-L343 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1637,5 +1637,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 8bdab20b17dced3421dcbabef03ab964)-->
+<!--[[[end]]] (checksum: 8a380158f2609a6fd59bb26ac2309da8)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -1494,7 +1494,7 @@ const decoder = select(
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L147-L329 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L148-L336 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1637,5 +1637,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: fd631bcba8e74716d31a85aa0b072986)-->
+<!--[[[end]]] (checksum: 594dee4c46ecd4d21b324c922798c624)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -1494,7 +1494,7 @@ const decoder = select(
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L148-L336 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L157-L348 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1637,5 +1637,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 594dee4c46ecd4d21b324c922798c624)-->
+<!--[[[end]]] (checksum: 8bdab20b17dced3421dcbabef03ab964)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -1494,7 +1494,7 @@ const decoder = select(
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L134-L304 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L147-L329 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1637,5 +1637,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: de389744084a828914f7353a71c33401)-->
+<!--[[[end]]] (checksum: fd631bcba8e74716d31a85aa0b072986)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -1494,7 +1494,7 @@ const decoder = select(
 
 ---
 
-<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L155-L343 'Source')
+<a href="#define">#</a> **define**&lt;<i style="color: #267f99">T</i>&gt;(fn: <i style="color: #267f99">(blob: unknown, ok, err) =&gt; DecodeResult&lt;T&gt;</i>): <i style="color: #267f99"><a href="/Decoder.html" style="color: inherit">Decoder</a>&lt;T&gt;</i> [<small>(source)</small>](https://github.com/nvie/decoders/tree/main/src/core/Decoder.ts#L147-L316 'Source')
 {: #define .signature}
 
 Defines a new `Decoder<T>`, by implementing a custom acceptance function.
@@ -1637,5 +1637,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 8a380158f2609a6fd59bb26ac2309da8)-->
+<!--[[[end]]] (checksum: 468d8d01806333072759356adf3b6df2)-->
 <!-- prettier-ignore-end -->

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -99,14 +99,6 @@ export interface Decoder<T> {
    */
   pipe<V, D extends Decoder<V>>(next: D): Decoder<DecoderType<D>>;
   pipe<V, D extends Decoder<V>>(next: (blob: T) => D): Decoder<DecoderType<D>>;
-
-  /**
-   * @internal
-   * Chain together the current decoder with another acceptance function, but
-   * also pass along the original input. Don't call this method directly.
-   * You'll probably want to use the higher-level `select()` decoder instead.
-   */
-  peek<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V>;
 }
 
 /**
@@ -310,24 +302,6 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
     });
   }
 
-  /**
-   * Chain together the current decoder with another acceptance function, but
-   * also pass along the original input.
-   *
-   * This is like `.then()`, but instead of this function receiving just
-   * the decoded result ``T``, it also receives the original input.
-   *
-   * This is an advanced, low-level, decoder. Don't call this method directly.
-   * Use the `select()` decoder instead.
-   */
-  // XXX I _think_ we can remove .peek() and move its implementation into select() directly
-  function peek<V>(next: AcceptanceFn<V, [unknown, T]>): Decoder<V> {
-    return define((blob, ok, err) => {
-      const result = decode(blob);
-      return result.ok ? next([blob, result.value], ok, err) : result;
-    });
-  }
-
   return brand({
     verify,
     value,
@@ -338,7 +312,6 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
     describe,
     then,
     pipe,
-    peek,
   });
 }
 

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -73,15 +73,14 @@ export interface Decoder<T> {
   describe(message: string): Decoder<T>;
 
   /**
-   * XXX Double-check these docs!
-   * XXX Keep these docs in sync!
    * Send the output of the current decoder into another decoder or acceptance
    * function. The given acceptance function will receive the output of the
-   * current decoder as its input, making it partially trusted.
+   * current decoder as its input.
    *
    * > _**NOTE:** This is an advanced, low-level, API. It's not recommended
    * > to reach for this construct unless there is no other way. Most cases can
-   * > be covered more elegantly by `.transform()` or `.refine()` instead._
+   * > be covered more elegantly by `.transform()`, `.refine()`, or `.pipe()`
+   * > instead._
    */
   then<V>(next: Next<V, T>): Decoder<V>;
 
@@ -231,15 +230,14 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
   }
 
   /**
-   * XXX Double-check these docs!
-   * XXX Keep these docs in sync!
    * Send the output of the current decoder into another decoder or acceptance
    * function. The given acceptance function will receive the output of the
-   * current decoder as its input, making it partially trusted.
+   * current decoder as its input.
    *
    * > _**NOTE:** This is an advanced, low-level, API. It's not recommended
    * > to reach for this construct unless there is no other way. Most cases can
-   * > be covered more elegantly by `.transform()` or `.refine()` instead._
+   * > be covered more elegantly by `.transform()`, `.refine()`, or `.pipe()`
+   * > instead._
    */
   function then<V>(next: Next<V, T>): Decoder<V> {
     return define((blob, ok, err) => {

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -93,6 +93,24 @@ export interface Decoder<T> {
   then<V>(next: Next<V, T>): Decoder<V>;
 
   /**
+   * If the current (first) decoder accepts the input, sends its output into
+   * the next (second) decoder, and return its results.
+   *
+   * This can be useful to validate the results of a previous transform, so in
+   * a typical example, you do something like this:
+   *
+   *   string
+   *     .transform(s => Number(s))
+   *     .pipe(positiveInteger)
+   *
+   * Note that the given decoder does not know anything about the given
+   * returned value. In the example above, for example, TypeScript knows that
+   * the input to the `positiveInteger` decoder will be of type `number`, but
+   * to the `positiveInteger` its input is completely opaque.
+   */
+  pipe<V>(next: Decoder<V>): Decoder<V>;
+
+  /**
    * @internal
    * Chain together the current decoder with another acceptance function, but
    * also pass along the original input. Don't call this method directly.
@@ -260,6 +278,27 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
   }
 
   /**
+   * If the current (first) decoder accepts the input, sends its output into
+   * the next (second) decoder, and return its results.
+   *
+   * This can be useful to validate the results of a previous transform, so in
+   * a typical example, you do something like this:
+   *
+   *   string
+   *     .transform(s => Number(s))
+   *     .pipe(positiveInteger)
+   *
+   * Note that the given decoder does not know anything about the given
+   * returned value. In the example above, for example, TypeScript knows that
+   * the input to the `positiveInteger` decoder will be of type `number`, but
+   * to the `positiveInteger` its input is completely opaque.
+   */
+  function pipe<V>(next: Decoder<V>): Decoder<V> {
+    // .pipe() is technically an alias of .then(), but has a simpler type signature
+    return then(next);
+  }
+
+  /**
    * Adds an extra predicate to a decoder. The new decoder is like the
    * original decoder, but only accepts values that aren't rejected by the
    * given function.
@@ -324,6 +363,7 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
     reject,
     describe,
     then,
+    pipe,
     peek,
   });
 }

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -259,6 +259,14 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
    * `unknown.then(...)`.
    */
   function then<V>(next: Next<V, T>): Decoder<V> {
+    //
+    // XXX Maybe split .then() into three pieces now?
+    //
+    //   - .pipe(nextDecoder)
+    //   - .thenFn(nextAcceptanceFn)
+    //   - .thenDecode(nextFnReturningDecoder) aka a better .peek()???
+    //
+
     // XXX Shorten!
     return define((blob, ok, err) => {
       const res1 = decode(blob);

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -64,6 +64,8 @@ export interface Decoder<T> {
   describe(message: string): Decoder<T>;
 
   /**
+   * XXX Double-check these docs!
+   * XXX Keep these docs in sync!
    * Send the output of the current decoder into another decoder or acceptance
    * function. The given acceptance function will receive the output of the
    * current decoder as its input, making it partially trusted.
@@ -75,6 +77,8 @@ export interface Decoder<T> {
   then<V>(next: Decoder<V> | AcceptanceFn<V, T>): Decoder<V>;
 
   /**
+   * XXX Double-check these docs!
+   * XXX Keep these docs in sync!
    * If the current (first) decoder accepts the input, sends its output into
    * the next (second) decoder, and return the second decoder's results.
    *
@@ -224,6 +228,8 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
   }
 
   /**
+   * XXX Double-check these docs!
+   * XXX Keep these docs in sync!
    * Send the output of the current decoder into another decoder or acceptance
    * function. The given acceptance function will receive the output of the
    * current decoder as its input, making it partially trusted.
@@ -243,6 +249,8 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
   }
 
   /**
+   * XXX Double-check these docs!
+   * XXX Keep these docs in sync!
    * Send the output of the current decoder to another decoder.
    *
    * This can be useful to validate the results of a previous transform, so in

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -12,8 +12,8 @@ export type DecodeResult<T> = Result<T, Annotation>;
  * `ok()` and `err()` constructor functions are passed in as the 2nd and 3rd
  * arguments for convenience. Return the result of calling one of these.
  *
- * The function may also return a Decoder<T> instance, in which case the same
- * input will be passed to the next decoder.
+ * The function may also return a Decoder<T> instance, in which case decoding
+ * will be deferred to that decoder instead.
  */
 export type AcceptanceFn<TOutput, TInput = unknown> = (
   blob: TInput,

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -12,24 +12,16 @@ export type DecodeResult<T> = Result<T, Annotation>;
  * `ok()` and `err()` constructor functions are provided as the 2nd and 3rd
  * param. One of these should be called and its value returned.
  */
-export type AcceptanceFn<T, InputT = unknown> = (
-  blob: InputT,
-  ok: (value: T) => DecodeResult<T>,
-  err: (msg: string | Annotation) => DecodeResult<T>,
-) => DecodeResult<T>;
-
-type AcceptanceFn2<TOutput, TInput> =
-  // XXX How to name this thing?
-  (
-    blob: TInput,
-    ok: (value: TOutput) => DecodeResult<TOutput>,
-    err: (msg: string | Annotation) => DecodeResult<TOutput>,
-  ) => DecodeResult<TOutput> | Decoder<TOutput>;
+export type AcceptanceFn<TOutput, TInput = unknown> = (
+  blob: TInput,
+  ok: (value: TOutput) => DecodeResult<TOutput>,
+  err: (msg: string | Annotation) => DecodeResult<TOutput>,
+) => DecodeResult<TOutput> | Decoder<TOutput>;
 
 // XXX Rename + document
 type Next<TOutput, TInput = unknown> =
   | Decoder<TOutput> // or...
-  | AcceptanceFn2<TOutput, TInput>;
+  | AcceptanceFn<TOutput, TInput>;
 
 export interface Decoder<T> {
   /**

--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -109,7 +109,7 @@ export interface Decoder<T> {
    * the input to the `positiveInteger` decoder will be of type `number`, but
    * to the `positiveInteger` its input is completely opaque.
    */
-  pipe<V>(next: Decoder<V>): Decoder<V>;
+  pipe<V, D extends Decoder<V>>(next: D): Decoder<DecoderType<D>>;
 
   /**
    * @internal
@@ -294,10 +294,10 @@ export function define<T>(fn: AcceptanceFn<T>): Decoder<T> {
    * the input to the `positiveInteger` decoder will be of type `number`, but
    * to the `positiveInteger` its input is completely opaque.
    */
-  function pipe<V>(next: Decoder<V>): Decoder<V> {
+  function pipe<V, D extends Decoder<V>>(next: D): Decoder<DecoderType<D>> {
     // .pipe() is technically an alias of .then(), it just has a simpler type
     // signature, making it friendlier to use
-    return then(next);
+    return then(next) as any;
   }
 
   /**

--- a/src/unions.ts
+++ b/src/unions.ts
@@ -175,8 +175,8 @@ export function select<T, D extends Decoder<unknown>>(
   scout: Decoder<T>,
   selectFn: (result: T) => D,
 ): Decoder<DecoderType<D>> {
-  return scout.peek(([blob, peekResult]) => {
-    const decoder = selectFn(peekResult);
-    return decoder.decode(blob);
+  return define((blob) => {
+    const result = scout.decode(blob);
+    return result.ok ? selectFn(result.value).decode(blob) : result;
   }) as Decoder<DecoderType<D>>;
 }

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -68,9 +68,6 @@ import {
   // Formatters
   formatInline,
   formatShort,
-
-  // Results
-  ok,
 } from '../dist';
 import { expectError, expectType, expectAssignable } from 'tsd';
 
@@ -166,7 +163,24 @@ string.verify('dummy', formatShort);
 expectType<number | undefined>(number.value('dummy'));
 expectType<string | undefined>(string.value('dummy'));
 
-expectType<number>(test(string.then((value: string) => ok(value.length))));
+expectType<number>(test(string.then((value: string, ok) => ok(value.length))));
+expectType<number>(
+  test(
+    string.then((value: string, ok, err) =>
+      Math.random() < 0.5 ? ok(value.length) : err('Nope'),
+    ),
+  ),
+);
+
+// .then()
+expectType<number>(test(string.transform(Number).then(positiveInteger)));
+expectType<number>(test(string.transform(Number).then(positiveInteger.decode)));
+expectType<boolean>(test(string.transform(Number).transform(String).then(truthy)));
+expectType<boolean>(test(string.transform(Number).transform(String).then(truthy.decode)));
+// XXX It would be HUGE if we could make this inference work!!!!!!!!
+// expectType<number | string>(
+//   test(string.transform(Number).then(Math.random() < 0.5 ? positiveInteger : string)),
+// );
 
 expectType<string>(test(string.refine((s) => s.startsWith('x'), 'Must start with x')));
 

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -10,6 +10,7 @@ import {
   date,
   datelike,
   decimal,
+  define,
   dict,
   either,
   email,
@@ -84,6 +85,8 @@ function foo(
   _r: DecoderType<typeof strings>,
   _s: DecoderType<typeof truthy>,
 ) {}
+
+expectType<123 | string>(test(define((blob, ok) => (blob === 123 ? ok(123) : string))));
 
 expectType<(p: string, q: number[], r: string[], s: boolean) => void>(foo);
 

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -182,6 +182,10 @@ expectType<boolean>(test(string.transform(Number).transform(String).then(truthy.
 //   test(string.transform(Number).then(Math.random() < 0.5 ? positiveInteger : string)),
 // );
 
+// .pipe()
+expectType<number>(test(string.transform(Number).pipe(positiveInteger)));
+expectType<boolean>(test(string.transform(Number).transform(String).pipe(truthy)));
+
 expectType<string>(test(string.refine((s) => s.startsWith('x'), 'Must start with x')));
 
 expectType<string>(

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -188,14 +188,13 @@ expectType<number>(test(string.transform(Number).then(positiveInteger)));
 expectType<number>(test(string.transform(Number).then(positiveInteger.decode)));
 expectType<boolean>(test(string.transform(Number).transform(String).then(truthy)));
 expectType<boolean>(test(string.transform(Number).transform(String).then(truthy.decode)));
-// XXX It would be HUGE if we could make this inference work!!!!!!!!
-// expectType<number | string>(
-//   test(string.transform(Number).then(Math.random() < 0.5 ? positiveInteger : string)),
-// );
 
 // .pipe()
 expectType<number>(test(string.transform(Number).pipe(positiveInteger)));
 expectType<boolean>(test(string.transform(Number).transform(String).pipe(truthy)));
+expectType<number | string>(
+  test(string.transform(Number).pipe(Math.random() < 0.5 ? positiveInteger : string)),
+);
 
 expectType<string>(test(string.refine((s) => s.startsWith('x'), 'Must start with x')));
 

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -171,6 +171,17 @@ expectType<number>(
     ),
   ),
 );
+expectType<number | string>(
+  test(
+    string.then((value: string, ok, err) =>
+      Math.random() < 0.3
+        ? ok(value.length)
+        : Math.random() < 0.5
+          ? ok(value)
+          : err('Nope'),
+    ),
+  ),
+);
 
 // .then()
 expectType<number>(test(string.transform(Number).then(positiveInteger)));

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -86,7 +86,14 @@ function foo(
   _s: DecoderType<typeof truthy>,
 ) {}
 
-expectType<123 | string>(test(define((blob, ok) => (blob === 123 ? ok(123) : string))));
+expectType<123 | 'hi'>(
+  test(
+    define((blob, ok, err) => {
+      expectType<unknown>(blob);
+      return Math.random() < 0.5 ? ok(123) : Math.random() < 0.5 ? ok('hi') : err('fail');
+    }),
+  ),
+);
 
 expectType<(p: string, q: number[], r: string[], s: boolean) => void>(foo);
 

--- a/test-d/inference.test-d.ts
+++ b/test-d/inference.test-d.ts
@@ -192,8 +192,19 @@ expectType<boolean>(test(string.transform(Number).transform(String).then(truthy.
 // .pipe()
 expectType<number>(test(string.transform(Number).pipe(positiveInteger)));
 expectType<boolean>(test(string.transform(Number).transform(String).pipe(truthy)));
+// .pipe() with branch infers decoder from both branches
 expectType<number | string>(
   test(string.transform(Number).pipe(Math.random() < 0.5 ? positiveInteger : string)),
+);
+// .pipe() with function with branches infers decoder from both branches
+expectType<number | string>(
+  test(
+    string.transform(Number).pipe(() => (Math.random() < 0.5 ? positiveInteger : string)),
+  ),
+);
+// .pipe() with input function with branches infers decoder from both branches
+expectType<number | string>(
+  test(string.transform(Number).pipe((x) => (x < 0.5 ? positiveInteger : string))),
 );
 
 expectType<string>(test(string.refine((s) => s.startsWith('x'), 'Must start with x')));

--- a/test/core/Decoder.test.ts
+++ b/test/core/Decoder.test.ts
@@ -123,6 +123,25 @@ describe('.then directly taking a decoder', () => {
   });
 });
 
+describe('.pipe (same as .then(decoder))', () => {
+  const decoder =
+    // We already know how to decode strings...
+    string.transform(Number).pipe(positiveInteger);
+
+  test('valid type of decode result', () => {
+    expect(decoder.verify('100')).toEqual(100);
+    expect(decoder.verify(' 123  ')).toEqual(123);
+    expect(decoder.verify('2387213979')).toEqual(2387213979);
+  });
+
+  test('invalid', () => {
+    expect(() => decoder.verify('not a numeric string')).toThrow('Number must be finite');
+    expect(() => decoder.verify(42)).toThrow('Must be string');
+    expect(() => decoder.verify('-123')).toThrow('Number must be positive');
+    expect(() => decoder.verify('3.14')).toThrow('Number must be an integer');
+  });
+});
+
 describe('.transform', () => {
   test('change type of decode result', () => {
     const len = string.transform((s) => s.length);

--- a/test/core/Decoder.test.ts
+++ b/test/core/Decoder.test.ts
@@ -10,15 +10,16 @@ test('.decode', () => {
   // .decode() is tested implicitly because it's used _everywhere_
 });
 
-describe('define', () => {
-  const decoder = define((blob, ok, err) =>
-    blob === 123
-      ? ok(123) // Either a decode result
-      : blob === 'now'
-        ? ok(new Date())
-        : blob === 'crash'
-          ? err('fail!')
-          : string,
+describe('define()', () => {
+  const decoder = define(
+    (blob, ok, err) =>
+      blob === 123
+        ? ok(123) // Either a decode result...
+        : blob === 'now'
+          ? ok(new Date()) // ...or another...
+          : blob === 'crash'
+            ? err('fail!') // ...or a failure...
+            : string, // ...or another decoder entirely
   );
 
   test('accepts', () => {
@@ -36,7 +37,7 @@ describe('define', () => {
   });
 });
 
-describe('.verify', () => {
+describe('.verify()', () => {
   test('valid', () => {
     const decoder = number;
     expect(decoder.verify(0)).toBe(0);
@@ -74,7 +75,7 @@ describe('.verify', () => {
   });
 });
 
-describe('.value', () => {
+describe('.value()', () => {
   test('valid', () => {
     const decoder = number;
     expect(decoder.value(0)).toBe(0);
@@ -90,7 +91,7 @@ describe('.value', () => {
   });
 });
 
-describe('.then with acceptance function', () => {
+describe('.then() with acceptance function', () => {
   const hex =
     // We already know how to decode strings...
     string.then(
@@ -112,10 +113,8 @@ describe('.then with acceptance function', () => {
   });
 });
 
-describe('.then with acceptance function returning a decoder', () => {
-  const decoder =
-    // We already know how to decode strings...
-    string.transform(Number).then(() => positiveInteger);
+describe('.then() with acceptance function returning a decoder', () => {
+  const decoder = string.transform(Number).then(() => positiveInteger);
 
   test('valid type of decode result', () => {
     expect(decoder.verify('100')).toEqual(100);
@@ -131,10 +130,8 @@ describe('.then with acceptance function returning a decoder', () => {
   });
 });
 
-describe('.then directly taking a decoder', () => {
-  const decoder =
-    // We already know how to decode strings...
-    string.transform(Number).then(positiveInteger);
+describe('.then() directly taking a decoder', () => {
+  const decoder = string.transform(Number).then(positiveInteger);
 
   test('valid type of decode result', () => {
     expect(decoder.verify('100')).toEqual(100);
@@ -150,10 +147,8 @@ describe('.then directly taking a decoder', () => {
   });
 });
 
-describe('.pipe with single decoder arg', () => {
-  const decoder =
-    // We already know how to decode strings...
-    string.transform(Number).pipe(positiveInteger);
+describe('.pipe() with single decoder arg', () => {
+  const decoder = string.transform(Number).pipe(positiveInteger);
 
   test('valid type of decode result', () => {
     expect(decoder.verify('100')).toEqual(100);
@@ -169,12 +164,10 @@ describe('.pipe with single decoder arg', () => {
   });
 });
 
-describe('.pipe with decoder function arg', () => {
-  const decoder =
-    // We already know how to decode strings...
-    string
-      .transform(Number)
-      .pipe((x) => (isNaN(x) || x <= 999 ? positiveInteger : always('A big number!')));
+describe('.pipe() with decoder function arg', () => {
+  const decoder = string
+    .transform(Number)
+    .pipe((x) => (isNaN(x) || x <= 999 ? positiveInteger : always('A big number!')));
 
   test('valid type of decode result', () => {
     expect(decoder.verify('0')).toEqual(0);
@@ -193,7 +186,7 @@ describe('.pipe with decoder function arg', () => {
   });
 });
 
-describe('.transform', () => {
+describe('.transform()', () => {
   test('change type of decode result', () => {
     const len = string.transform((s) => s.length);
     expect(len.verify('foo')).toEqual(3);
@@ -226,7 +219,7 @@ describe('.transform', () => {
   });
 });
 
-describe('.refine', () => {
+describe('.refine()', () => {
   const odd = number.refine((n) => n % 2 !== 0, 'Must be odd');
 
   test('valid', () => {
@@ -244,7 +237,7 @@ describe('.refine', () => {
   });
 });
 
-describe('.reject (simple)', () => {
+describe('.reject() (simple)', () => {
   const decoder = pojo.reject((obj) => {
     const badKeys = Object.keys(obj).filter((key) => key.startsWith('_'));
     return badKeys.length > 0 ? `Disallowed keys: ${badKeys.join(', ')}` : null;
@@ -258,7 +251,7 @@ describe('.reject (simple)', () => {
   });
 });
 
-describe('.reject (w/ Annotation)', () => {
+describe('.reject() (w/ Annotation)', () => {
   const odd = number.reject((n) =>
     n % 2 === 0 ? annotate('***', "Can't show ya, but this must be odd") : null,
   );
@@ -278,7 +271,7 @@ describe('.reject (w/ Annotation)', () => {
   });
 });
 
-describe('.describe', () => {
+describe('.describe()', () => {
   const decoder = string.describe('Must be text');
 
   test('valid', () => {

--- a/test/core/Decoder.test.ts
+++ b/test/core/Decoder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { annotate, formatInline, formatShort } from '~/core';
+import { annotate, define, formatInline, formatShort } from '~/core';
 import { number, positiveInteger } from '~/numbers';
 import { pojo } from '~/objects';
 import { string } from '~/strings';
@@ -8,6 +8,32 @@ import { always } from '~/basics';
 
 test('.decode', () => {
   // .decode() is tested implicitly because it's used _everywhere_
+});
+
+describe('define', () => {
+  const decoder = define((blob, ok, err) =>
+    blob === 123
+      ? ok(123) // Either a decode result
+      : blob === 'now'
+        ? ok(new Date())
+        : blob === 'crash'
+          ? err('fail!')
+          : string,
+  );
+
+  test('accepts', () => {
+    expect(decoder.verify(123)).toEqual(123);
+    expect(decoder.verify('now')).toEqual(expect.any(Date));
+    expect(decoder.verify('abc')).toEqual('abc');
+    expect(decoder.verify('hey')).toEqual('hey');
+  });
+
+  test('rejects', () => {
+    expect(() => decoder.verify(0)).toThrow();
+    expect(() => decoder.verify(new Date())).toThrow();
+    expect(() => decoder.verify([])).toThrow();
+    expect(() => decoder.verify('crash')).toThrow(/fail!/);
+  });
 });
 
 describe('.verify', () => {

--- a/test/core/Decoder.test.ts
+++ b/test/core/Decoder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { annotate, formatInline, formatShort } from '~/core';
-import { number } from '~/numbers';
+import { number, positiveInteger } from '~/numbers';
 import { pojo } from '~/objects';
 import { string } from '~/strings';
 
@@ -63,7 +63,7 @@ describe('.value', () => {
   });
 });
 
-describe('.then', () => {
+describe('.then with acceptance function', () => {
   const hex =
     // We already know how to decode strings...
     string.then(
@@ -82,6 +82,44 @@ describe('.then', () => {
 
   test('invalid', () => {
     expect(() => hex.verify('no good hex value')).toThrow('Nope');
+  });
+});
+
+describe('.then with acceptance function returning a decoder', () => {
+  const decoder =
+    // We already know how to decode strings...
+    string.transform(Number).then(() => positiveInteger);
+
+  test('valid type of decode result', () => {
+    expect(decoder.verify('100')).toEqual(100);
+    expect(decoder.verify(' 123  ')).toEqual(123);
+    expect(decoder.verify('2387213979')).toEqual(2387213979);
+  });
+
+  test('invalid', () => {
+    expect(() => decoder.verify('not a numeric string')).toThrow('Number must be finite');
+    expect(() => decoder.verify(42)).toThrow('Must be string');
+    expect(() => decoder.verify('-123')).toThrow('Number must be positive');
+    expect(() => decoder.verify('3.14')).toThrow('Number must be an integer');
+  });
+});
+
+describe('.then directly taking a decoder', () => {
+  const decoder =
+    // We already know how to decode strings...
+    string.transform(Number).then(positiveInteger);
+
+  test('valid type of decode result', () => {
+    expect(decoder.verify('100')).toEqual(100);
+    expect(decoder.verify(' 123  ')).toEqual(123);
+    expect(decoder.verify('2387213979')).toEqual(2387213979);
+  });
+
+  test('invalid', () => {
+    expect(() => decoder.verify('not a numeric string')).toThrow('Number must be finite');
+    expect(() => decoder.verify(42)).toThrow('Must be string');
+    expect(() => decoder.verify('-123')).toThrow('Number must be positive');
+    expect(() => decoder.verify('3.14')).toThrow('Number must be an integer');
   });
 });
 

--- a/test/core/Decoder.test.ts
+++ b/test/core/Decoder.test.ts
@@ -17,23 +17,19 @@ describe('define()', () => {
         ? ok(123) // Either a decode result...
         : blob === 'now'
           ? ok(new Date()) // ...or another...
-          : blob === 'crash'
-            ? err('fail!') // ...or a failure...
-            : string, // ...or another decoder entirely
+          : err('fail!'), // ...or a failure...
   );
 
   test('accepts', () => {
     expect(decoder.verify(123)).toEqual(123);
     expect(decoder.verify('now')).toEqual(expect.any(Date));
-    expect(decoder.verify('abc')).toEqual('abc');
-    expect(decoder.verify('hey')).toEqual('hey');
   });
 
   test('rejects', () => {
     expect(() => decoder.verify(0)).toThrow();
     expect(() => decoder.verify(new Date())).toThrow();
     expect(() => decoder.verify([])).toThrow();
-    expect(() => decoder.verify('crash')).toThrow(/fail!/);
+    expect(() => decoder.verify('hey')).toThrow(/fail!/);
   });
 });
 

--- a/test/core/Decoder.test.ts
+++ b/test/core/Decoder.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest';
 
+import { always } from '~/basics';
 import { annotate, define, formatInline, formatShort } from '~/core';
 import { number, positiveInteger } from '~/numbers';
 import { pojo } from '~/objects';
 import { string } from '~/strings';
-import { always } from '~/basics';
 
 test('.decode', () => {
   // .decode() is tested implicitly because it's used _everywhere_

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -174,12 +174,18 @@ describe('numeric', () => {
   test('fuzz', () => {
     return fc.assert(
       fc.property(fc.anything(), (input) => {
-        if (typeof input === 'string' && !isNaN(Number(input)) && /\S/.test(input)) {
+        if (
+          typeof input === 'string' &&
+          !isNaN(Number(input)) &&
+          /\S/.test(input) &&
+          input.trim() === input
+        ) {
           expect(decoder.verify(input)).toBe(Number(input));
         } else {
           expect(() => decoder.verify(input)).toThrow();
         }
       }),
+      { examples: [['0 ']] },
     );
   });
 });


### PR DESCRIPTION
A new `.pipe()` method on Decoder allows you to pass the output of one decoder as input to another:

```ts
string
  .transform((s) => s.split(','))
  .pipe(array(nonEmptyString));
```

This was previously possible already with `.then`, but it was a bit more ugly than it had to be, i.e.:

```ts
string
  .transform((s) => s.split(','))
  .then(array(nonEmptyString).decode); // Yuck, no longer :)
```

#### Dynamic decoder selection with ``.pipe()``

The new `.pipe()` also works with dynamic decoder selection based on a runtime value:

```ts
unknown
  .pipe((val) => Math.random() < 0.5 ? numeric : email);
// Decoder<string | number>
```
