### PR TITLE
Remove incorrect `positiveNumber` example from docs

### DIFF
--- a/docs/_data.py
+++ b/docs/_data.py
@@ -299,7 +299,6 @@ DECODERS = {
 
       // 👎
       positiveNumber.verify(-42);             // throws
-      positiveNumber.verify(3.14);            // throws
       positiveNumber.verify(Infinity);        // throws
       positiveNumber.verify(NaN);             // throws
       positiveNumber.verify('not a number');  // throws

--- a/docs/api.md
+++ b/docs/api.md
@@ -1615,5 +1615,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 61b09f8be5bf4d960fcba916cba0e8cf)-->
+<!--[[[end]]] (checksum: cc6d360b38f7fdbff61c198f8218ad07)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -448,7 +448,6 @@ positiveNumber.verify(0) === 0;
 
 // 👎
 positiveNumber.verify(-42);             // throws
-positiveNumber.verify(3.14);            // throws
 positiveNumber.verify(Infinity);        // throws
 positiveNumber.verify(NaN);             // throws
 positiveNumber.verify('not a number');  // throws


### PR DESCRIPTION
I was looking through the docs and noticed that `positiveNumber.verify(3.14)` was listed as an example of something should throw an error, even though 3.14 is indeed a positive number. This was likely just a copypasta from the `positiveInterger` examples.