### PR TITLE
Fix formatting of `httpsUrl` and `identifier` docs

### DIFF
--- a/docs/_data.py
+++ b/docs/_data.py
@@ -165,7 +165,7 @@ DECODERS = {
       httpsUrl.verify('git+ssh://user@github.com/foo/bar.git');  // throws, not HTTPS
       ```
 
-      **Tip!** If you need to limit URLs to different protocols than HTTP, you can do as the HTTPS decoder is implemented: by adding further conditions using an `.refine()` call.
+      **Tip!** If you need to limit URLs to different protocols than HTTP, you can do as the HTTPS decoder is implemented: by adding further conditions using a `.refine()` call.
 
       ```ts
       import { url } from 'decoders';

--- a/docs/_data.py
+++ b/docs/_data.py
@@ -156,6 +156,7 @@ DECODERS = {
     'params': None,
     'return_type': 'Decoder<URL>',
     'example': """
+      ```ts
       // 👍
       httpsUrl.verify('https://nvie.com:443') === new URL('https://nvie.com/');
 
@@ -173,6 +174,7 @@ DECODERS = {
         (value) => value.protocol === 'git:',
         'Must be a git:// URL',
       );
+      ```
     """,
   },
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -268,6 +268,7 @@ url.verify('/search?q=foo');     // throws
 Accepts strings that are valid URLs, but only HTTPS ones. Returns the value
 as a URL instance.
 
+```ts
 // 👍
 httpsUrl.verify('https://nvie.com:443') === new URL('https://nvie.com/');
 
@@ -285,6 +286,7 @@ const gitUrl: Decoder<URL> = url.refine(
   (value) => value.protocol === 'git:',
   'Must be a git:// URL',
 );
+```
 
 ---
 
@@ -1616,5 +1618,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: 61b09f8be5bf4d960fcba916cba0e8cf)-->
+<!--[[[end]]] (checksum: f1b15961ef6fc5f0c6516084dcc4561c)-->
 <!-- prettier-ignore-end -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -277,7 +277,7 @@ httpsUrl.verify('http://nvie.com');                        // throws, not HTTPS
 httpsUrl.verify('git+ssh://user@github.com/foo/bar.git');  // throws, not HTTPS
 ```
 
-**Tip!** If you need to limit URLs to different protocols than HTTP, you can do as the HTTPS decoder is implemented: by adding further conditions using an [`.refine()`](/Decoder.html#refine) call.
+**Tip!** If you need to limit URLs to different protocols than HTTP, you can do as the HTTPS decoder is implemented: by adding further conditions using a [`.refine()`](/Decoder.html#refine) call.
 
 ```ts
 import { url } from 'decoders';
@@ -1618,5 +1618,5 @@ const treeDecoder: Decoder<Tree> = object({
 });
 ```
 
-<!--[[[end]]] (checksum: f1b15961ef6fc5f0c6516084dcc4561c)-->
+<!--[[[end]]] (checksum: 3f0b6e1da4611aeab76f59cc562c3487)-->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
I was looking through the release notes for the latest version and clicked on the link for the new `identifier` decoder and noticed that it didn't scroll to the right section on the page. I scrolled a bit and noticed the `httpsUrl` section looked a little weird, with the `identifier` docs included in the code block:

<img width="1034" alt="Screenshot 2024-01-21 at 9 48 28 PM" src="https://github.com/nvie/decoders/assets/4155779/32bd9698-7b67-4468-9ba6-6dc9ca791bb6">


It looks like some code block syntax was removed in https://github.com/nvie/decoders/commit/961ec80c11f491d8cb082cae627f365092c73b35#diff-151ce10db0d2acef9abdc806c5381a40373ac8ef879d15063d833a7fb34070c2L171, likely causing the formatting issue. This PR restores that syntax and should fix the formatting on the page.